### PR TITLE
Rjwebb/let moderator manually change synced fields

### DIFF
--- a/client/.eslintrc.yml
+++ b/client/.eslintrc.yml
@@ -17,7 +17,7 @@ rules:
   # TODO: Migrate to camelcase.
   # snake_case API params and properties makes this a tangled process.
   camelcase: off
-parser: babel-eslint
+parser: '@typescript-eslint/parser'
 parserOptions:
   ecmaFeatures:
     jsx: true

--- a/client/package.json
+++ b/client/package.json
@@ -32,6 +32,7 @@
     "compression-webpack-plugin": "~7.1.2",
     "copy-webpack-plugin": "~9.0.1",
     "css-loader": "^6.8.1",
+    "dotenv": "^16.3.1",
     "eslint": "~7.20.0",
     "eslint-config-prettier": "~8.1.0",
     "eslint-config-standard": "~16.0.2",

--- a/client/src/pages/admin/CheckboxField.tsx
+++ b/client/src/pages/admin/CheckboxField.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from "react"
 import { useDispatch, useSelector } from "react-redux"
-import { Box, Flex, Text } from "theme-ui"
+import { Box, Text } from "theme-ui"
 import PropTypes from "prop-types"
 
 import { handleZidMetadataUpdate } from "../../actions"
 import { RootState } from "../../util/types"
 
-export const CheckboxField = ({ field, label = "", children = "", isIntegerBool = false }) => {
+export const CheckboxField = ({ field, label = "", subtitle = "", isIntegerBool = false }) => {
   const { zid_metadata } = useSelector((state: RootState) => state.zid_metadata)
   const [state, setState] = useState(zid_metadata[field])
   const dispatch = useDispatch()
@@ -42,7 +42,7 @@ export const CheckboxField = ({ field, label = "", children = "", isIntegerBool 
         />
         &nbsp;<strong>{label}</strong>
       </label>
-      <Text sx={{ display: "inline", ml: [2], color: "lightGray" }}>{children}</Text>
+      {subtitle && <Text sx={{ display: "inline", ml: [2], color: "lightGray" }}>{subtitle}</Text>}
     </Box>
   )
 }
@@ -50,6 +50,6 @@ export const CheckboxField = ({ field, label = "", children = "", isIntegerBool 
 CheckboxField.propTypes = {
   field: PropTypes.string.isRequired,
   label: PropTypes.string,
-  children: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
+  subtitle: PropTypes.string,
   isIntegerBool: PropTypes.bool,
 }

--- a/client/src/pages/admin/conversation-config.tsx
+++ b/client/src/pages/admin/conversation-config.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 
-import { useCallback, useState, useEffect } from "react"
+import { useCallback, useState, useEffect, ComponentProps } from "react"
 import PropTypes from "prop-types"
 import { connect } from "react-redux"
 import { Link } from "react-router-dom"
@@ -15,6 +15,39 @@ import SeedComment from "./seed-comment"
 import api from "../../util/api"
 import Url from "../../util/url"
 import { RootState } from "../../util/types"
+
+
+const Input = (props: ComponentProps<"input">) =>
+  <input
+    sx={{
+      fontFamily: "body",
+      fontSize: [2],
+      width: "100%",
+      maxWidth: "35em",
+      borderRadius: 2,
+      padding: [2],
+      border: "1px solid",
+      borderColor: "mediumGray",
+    }}
+    {...props}
+  />
+
+const Textarea = (props: ComponentProps<"textarea">) =>
+  <textarea
+    sx={{
+      fontFamily: "body",
+      fontSize: [2],
+      width: "100%",
+      maxWidth: "35em",
+      height: "7em",
+      resize: "none",
+      padding: [2],
+      borderRadius: 2,
+      border: "1px solid",
+      borderColor: "mediumGray",
+    }}
+    {...props}
+  />
 
 const ConversationConfig = ({ dispatch, zid_metadata, error }) => {
   // {
@@ -119,39 +152,17 @@ const ConversationConfig = ({ dispatch, zid_metadata, error }) => {
 
       <Box sx={{ mb: [3] }}>
         <Text sx={{ mb: [2] }}>Title</Text>
-        <input
-          sx={{
-            fontFamily: "body",
-            fontSize: [2],
-            width: "100%",
-            maxWidth: "35em",
-            borderRadius: 2,
-            padding: [2],
-            border: "1px solid",
-            borderColor: "mediumGray",
-          }}
-          onBlur={(e) => handleStringValueChange("topic", e.target.value)}
+        <Input
+          onBlur={(e) => handleStringValueChange("topic", e.target)}
           defaultValue={zid_metadata.topic}
         />
       </Box>
 
       <Box sx={{ mb: [3] }}>
-        <Text sx={{ mb: [2] }}>Instructions</Text>
-        <textarea
-          sx={{
-            fontFamily: "body",
-            fontSize: [2],
-            width: "100%",
-            maxWidth: "35em",
-            height: "7em",
-            resize: "none",
-            padding: [2],
-            borderRadius: 2,
-            border: "1px solid",
-            borderColor: "mediumGray",
-          }}
+        <Text sx={{ mb: [2] }}>Description</Text>
+        <Textarea
           data-test-id="description"
-          onBlur={(e) => handleStringValueChange("description", e.target.value)}
+          onBlur={(e) => handleStringValueChange("description", e.target)}
           defaultValue={zid_metadata.description}
         />
       </Box>
@@ -170,18 +181,8 @@ const ConversationConfig = ({ dispatch, zid_metadata, error }) => {
           Votes Expected
           <Text sx={{ display: "inline", color: "lightGray", ml: [2] }}>Optional</Text>
         </Text>
-        <input
-          sx={{
-            fontFamily: "body",
-            fontSize: [2],
-            width: "100%",
-            maxWidth: "35em",
-            borderRadius: 2,
-            padding: [2],
-            border: "1px solid",
-            borderColor: "mediumGray",
-          }}
-          onBlur={(e) => handleIntegerValueChange("postsurvey_limit", e.target.value)}
+        <Input
+          onBlur={(e) => handleIntegerValueChange("postsurvey_limit", e.target)}
           defaultValue={zid_metadata.postsurvey_limit || ""}
         />
       </Box>
@@ -191,19 +192,9 @@ const ConversationConfig = ({ dispatch, zid_metadata, error }) => {
           Statements Expected
           <Text sx={{ display: "inline", color: "lightGray", ml: [2] }}>Optional</Text>
         </Text>
-        <input
-          sx={{
-            fontFamily: "body",
-            fontSize: [2],
-            width: "100%",
-            maxWidth: "35em",
-            borderRadius: 2,
-            padding: [2],
-            border: "1px solid",
-            borderColor: "mediumGray",
-          }}
+        <Input
           onBlur={(e) =>
-            handleIntegerValueChange("postsurvey_submission", e.target.value)
+            handleIntegerValueChange("postsurvey_submission", e.target)
           }
           defaultValue={zid_metadata.postsurvey_submissions || ""}
         />
@@ -229,7 +220,7 @@ const ConversationConfig = ({ dispatch, zid_metadata, error }) => {
             borderColor: "mediumGray",
           }}
           data-test-id="postsurvey"
-          onBlur={(e) => handleStringValueChange("postsurvey", e.target.value)}
+          onBlur={(e) => handleStringValueChange("postsurvey", e.target)}
           defaultValue={zid_metadata.postsurvey}
         />
       </Box>
@@ -241,20 +232,10 @@ const ConversationConfig = ({ dispatch, zid_metadata, error }) => {
             Optional. Shown as a button after the survey
           </Text>
         </Text>
-        <input
+        <Input
           placeholder="https://"
-          sx={{
-            fontFamily: "body",
-            fontSize: [2],
-            width: "100%",
-            maxWidth: "35em",
-            borderRadius: 2,
-            padding: [2],
-            border: "1px solid",
-            borderColor: "mediumGray",
-          }}
           onBlur={(e) =>
-            handleStringValueChange("postsurveyRedirect", e.target.value)
+            handleStringValueChange("postsurveyRedirect", e.target)
           }
           defaultValue={zid_metadata.postsurvey_redirect || ""}
         />
@@ -362,7 +343,7 @@ const ConversationConfig = ({ dispatch, zid_metadata, error }) => {
 
 ConversationConfig.propTypes = {
   dispatch: PropTypes.func,
-  zid_metadata: {
+  zid_metadata: PropTypes.shape({
     conversation_id: PropTypes.string,
     topic: PropTypes.string, // actually: title
     description: PropTypes.string, // actually: intro text
@@ -373,7 +354,7 @@ ConversationConfig.propTypes = {
     postsurvey_redirect: PropTypes.string,
     is_owner: PropTypes.bool,
     is_mod: PropTypes.bool
-  },
+  }),
   error: PropTypes.string,
   loading: PropTypes.bool
 }

--- a/client/src/pages/admin/conversation-config.tsx
+++ b/client/src/pages/admin/conversation-config.tsx
@@ -126,6 +126,19 @@ const ConversationConfig: React.FC<{
         )}
       </Box>
 
+      <Heading as="h3" sx={{ mt: 5, mb: 4 }}>
+        GitHub Synced Data
+      </Heading>
+
+      <Box sx={{ mb: [4], fontStyle: "italic" }}>
+        The fields in this section are automatically synced from GitHub. To change them, please
+        modify the source pull request, or disable syncing by unchecking the box below.
+      </Box>
+
+      <CheckboxField field="github_sync_enabled" label="Enable GitHub sync">
+        Uncheck in order to disable syncing
+      </CheckboxField>
+
       <Box sx={{ mb: [3] }}>
         <Text sx={{ mb: [2] }}>Title</Text>
         <input

--- a/client/src/pages/admin/conversation-config.tsx
+++ b/client/src/pages/admin/conversation-config.tsx
@@ -46,14 +46,6 @@ const ConversationConfig: React.FC<{
 
   //                document.location = `/r/${conversation_id}/${this.state.reports[0].report_id}`
 
-  const topicRef = useRef<HTMLInputElement>()
-  const descriptionRef = useRef<HTMLTextAreaElement>()
-  const survey_captionRef = useRef<HTMLTextAreaElement>()
-  const postsurveyRef = useRef<HTMLTextAreaElement>()
-  const postsurveyLimitRef = useRef<HTMLInputElement>()
-  const postsurveySubmissionsRef = useRef<HTMLInputElement>()
-  const postsurveyRedirectRef = useRef<HTMLInputElement>()
-
   const [updatedZidMetadata, setUpdatedZidMetadata] = useState(zid_metadata)
 
   const handleStringValueChange = useCallback(
@@ -146,7 +138,6 @@ const ConversationConfig: React.FC<{
       <Box sx={{ mb: [3] }}>
         <Text sx={{ mb: [2] }}>Title</Text>
         <input
-          ref={topicRef}
           sx={{
             fontFamily: "body",
             fontSize: [2],
@@ -157,7 +148,7 @@ const ConversationConfig: React.FC<{
             border: "1px solid",
             borderColor: "mediumGray",
           }}
-          onBlur={(e) => handleStringValueChange("topic", topicRef.current)}
+          onBlur={(e) => handleStringValueChange("topic", e.target.value)}
           defaultValue={zid_metadata.topic}
         />
       </Box>
@@ -165,7 +156,6 @@ const ConversationConfig: React.FC<{
       <Box sx={{ mb: [3] }}>
         <Text sx={{ mb: [2] }}>Instructions</Text>
         <textarea
-          ref={descriptionRef}
           sx={{
             fontFamily: "body",
             fontSize: [2],
@@ -179,7 +169,7 @@ const ConversationConfig: React.FC<{
             borderColor: "mediumGray",
           }}
           data-test-id="description"
-          onBlur={(e) => handleStringValueChange("description", descriptionRef.current)}
+          onBlur={(e) => handleStringValueChange("description", e.target.value)}
           defaultValue={zid_metadata.description}
         />
       </Box>
@@ -199,7 +189,6 @@ const ConversationConfig: React.FC<{
           <Text sx={{ display: "inline", color: "lightGray", ml: [2] }}>Optional</Text>
         </Text>
         <input
-          ref={postsurveyLimitRef}
           sx={{
             fontFamily: "body",
             fontSize: [2],
@@ -210,7 +199,7 @@ const ConversationConfig: React.FC<{
             border: "1px solid",
             borderColor: "mediumGray",
           }}
-          onBlur={(e) => handleIntegerValueChange("postsurvey_limit", postsurveyLimitRef.current)}
+          onBlur={(e) => handleIntegerValueChange("postsurvey_limit", e.target.value)}
           defaultValue={zid_metadata.postsurvey_limit || ""}
         />
       </Box>
@@ -221,7 +210,6 @@ const ConversationConfig: React.FC<{
           <Text sx={{ display: "inline", color: "lightGray", ml: [2] }}>Optional</Text>
         </Text>
         <input
-          ref={postsurveySubmissionsRef}
           sx={{
             fontFamily: "body",
             fontSize: [2],
@@ -233,7 +221,7 @@ const ConversationConfig: React.FC<{
             borderColor: "mediumGray",
           }}
           onBlur={(e) =>
-            handleIntegerValueChange("postsurvey_submission", postsurveySubmissionsRef.current)
+            handleIntegerValueChange("postsurvey_submission", e.target.value)
           }
           defaultValue={zid_metadata.postsurvey_submissions || ""}
         />
@@ -246,7 +234,6 @@ const ConversationConfig: React.FC<{
         </Text>
         <textarea
           placeholder="You’re all done! Thanks for contributing your input. You can expect to hear back from us after..."
-          ref={postsurveyRef}
           sx={{
             fontFamily: "body",
             fontSize: [2],
@@ -260,7 +247,7 @@ const ConversationConfig: React.FC<{
             borderColor: "mediumGray",
           }}
           data-test-id="postsurvey"
-          onBlur={(e) => handleStringValueChange("postsurvey", postsurveyRef.current)}
+          onBlur={(e) => handleStringValueChange("postsurvey", e.target.value)}
           defaultValue={zid_metadata.postsurvey}
         />
       </Box>
@@ -274,7 +261,6 @@ const ConversationConfig: React.FC<{
         </Text>
         <input
           placeholder="https://"
-          ref={postsurveyRedirectRef}
           sx={{
             fontFamily: "body",
             fontSize: [2],
@@ -286,7 +272,7 @@ const ConversationConfig: React.FC<{
             borderColor: "mediumGray",
           }}
           onBlur={(e) =>
-            handleStringValueChange("postsurveyRedirect", postsurveyRedirectRef.current)
+            handleStringValueChange("postsurveyRedirect", e.target.value)
           }
           defaultValue={zid_metadata.postsurvey_redirect || ""}
         />

--- a/client/src/pages/admin/conversation-config.tsx
+++ b/client/src/pages/admin/conversation-config.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 
-import React, { useRef, useCallback, useState, useEffect } from "react"
+import { useCallback, useState, useEffect } from "react"
+import PropTypes from "prop-types"
 import { connect } from "react-redux"
 import { Link } from "react-router-dom"
 import { Heading, Box, Text, jsx } from "theme-ui"
@@ -13,26 +14,9 @@ import SeedComment from "./seed-comment"
 
 import api from "../../util/api"
 import Url from "../../util/url"
-import ComponentHelpers from "../../util/component-helpers"
 import { RootState } from "../../util/types"
 
-const ConversationConfig: React.FC<{
-  dispatch: Function;
-  zid_metadata: {
-    conversation_id: string;
-    topic: string; // actually: title
-    description: string; // actually: intro text
-    survey_caption: string;
-    postsurvey: string;
-    postsurvey_limit: string;
-    postsurvey_submissions: string;
-    postsurvey_redirect: string;
-    is_owner: boolean;
-    is_mod: boolean;
-  };
-  error: string;
-  loading: boolean;
-}> = ({ dispatch, zid_metadata, error, loading }) => {
+const ConversationConfig = ({ dispatch, zid_metadata, error }) => {
   // {
   //    const reportsPromise = api.get("/api/v3/reports", {
   //      conversation_id: this.props.conversation_id,
@@ -46,7 +30,6 @@ const ConversationConfig: React.FC<{
 
   //                document.location = `/r/${conversation_id}/${this.state.reports[0].report_id}`
 
-  const [updatedZidMetadata, setUpdatedZidMetadata] = useState(zid_metadata)
 
   const handleStringValueChange = useCallback(
     (field: string, element) => {
@@ -60,7 +43,6 @@ const ConversationConfig: React.FC<{
       if (element.value === "") {
         dispatch(handleZidMetadataUpdate(zid_metadata, field, 0))
       } else {
-        const val = parseInt(element.value, 10)
         if (isNaN(element.value) || element.value.toString() !== element.value) {
           toast.error("Invalid value")
           return
@@ -113,7 +95,7 @@ const ConversationConfig: React.FC<{
         {reports && reports[0] && (
           <Link
             sx={{ variant: "styles.a", ml: [3] }}
-            to={"/r/" + zid_metadata.conversation_id + "/" + (reports[0] as any)?.report_id}
+            to={"/r/" + zid_metadata.conversation_id + "/" + (reports[0] as any).report_id}
           >
             Go to report
           </Link>
@@ -368,7 +350,7 @@ const ConversationConfig: React.FC<{
         {reports && reports[0] && (
           <Link
             sx={{ variant: "styles.a", ml: [3] }}
-            to={"/r/" + zid_metadata.conversation_id + "/" + (reports[0] as any)?.report_id}
+            to={"/r/" + zid_metadata.conversation_id + "/" + (reports[0] as any).report_id}
           >
             Go to report
           </Link>
@@ -376,6 +358,24 @@ const ConversationConfig: React.FC<{
       </Box>
     </Box>
   )
+}
+
+ConversationConfig.propTypes = {
+  dispatch: PropTypes.func,
+  zid_metadata: {
+    conversation_id: PropTypes.string,
+    topic: PropTypes.string, // actually: title
+    description: PropTypes.string, // actually: intro text
+    survey_caption: PropTypes.string,
+    postsurvey: PropTypes.string,
+    postsurvey_limit: PropTypes.string,
+    postsurvey_submissions: PropTypes.string,
+    postsurvey_redirect: PropTypes.string,
+    is_owner: PropTypes.bool,
+    is_mod: PropTypes.bool
+  },
+  error: PropTypes.string,
+  loading: PropTypes.bool
 }
 
 export default connect((state: RootState) => state.user)(

--- a/client/src/pages/admin/conversation-config.tsx
+++ b/client/src/pages/admin/conversation-config.tsx
@@ -116,7 +116,17 @@ const ConversationConfig = ({ dispatch, zid_metadata, error }) => {
         Configure
       </Heading>
 
-      Conversation for PR <a href={`https://github.com/${FIP_REPO_OWNER}/${FIP_REPO_NAME}/pull/${zid_metadata.github_pr_id}`}>#{zid_metadata.github_pr_id}</a>
+      <Box sx={{ mb: [3] }}>
+        PR <a href={`https://github.com/${FIP_REPO_OWNER}/${FIP_REPO_NAME}/pull/${zid_metadata.github_pr_id}`}>#{zid_metadata.github_pr_id}</a>
+      </Box>
+
+      <Box sx={{ mb: [3] }}>
+        Branch <strong>{zid_metadata.github_branch_name}</strong> on <strong>{zid_metadata.github_repo_owner}/{zid_metadata.github_repo_name}</strong>
+      </Box>
+
+      <Box sx={{ mb: [3] }}>
+        Submitted by <strong>{zid_metadata.github_pr_submitter}</strong>
+      </Box>
 
       <Box sx={{ mb: [4] }}>{error ? <Text>Error Saving</Text> : null}</Box>
 
@@ -156,10 +166,11 @@ const ConversationConfig = ({ dispatch, zid_metadata, error }) => {
       />
 
       <Box sx={{ mb: [3] }}>
-        <Text sx={{ mb: [2] }}>Title</Text>
+        <Text sx={{ mb: [2] }}>FIP title</Text>
         <Input
-          onBlur={(e) => handleStringValueChange("topic", e.target)}
-          defaultValue={zid_metadata.topic}
+          onBlur={(e) => handleStringValueChange("fip_title", e.target)}
+          defaultValue={zid_metadata.fip_title}
+          disabled={zid_metadata.github_sync_enabled}
         />
       </Box>
 
@@ -169,6 +180,62 @@ const ConversationConfig = ({ dispatch, zid_metadata, error }) => {
           data-test-id="description"
           onBlur={(e) => handleStringValueChange("description", e.target)}
           defaultValue={zid_metadata.description}
+          disabled={zid_metadata.github_sync_enabled}
+        />
+      </Box>
+
+      <Box sx={{ mb: [3] }}>
+        <Text sx={{ mb: [2] }}>FIP author</Text>
+        <Input
+          onBlur={(e) => handleStringValueChange("fip_author", e.target)}
+          defaultValue={zid_metadata.fip_author}
+          disabled={zid_metadata.github_sync_enabled}
+        />
+      </Box>
+
+
+      <Box sx={{ mb: [3] }}>
+        <Text sx={{ mb: [2] }}>FIP discussions link</Text>
+        <Input
+          onBlur={(e) => handleStringValueChange("fip_discussions_to", e.target)}
+          defaultValue={zid_metadata.fip_discussions_to}
+          disabled={zid_metadata.github_sync_enabled}
+        />
+      </Box>
+
+      <Box sx={{ mb: [3] }}>
+        <Text sx={{ mb: [2] }}>FIP status</Text>
+        <Input
+          onBlur={(e) => handleStringValueChange("fip_status", e.target)}
+          defaultValue={zid_metadata.fip_status}
+          disabled={zid_metadata.github_sync_enabled}
+        />
+      </Box>
+
+      <Box sx={{ mb: [3] }}>
+        <Text sx={{ mb: [2] }}>FIP type</Text>
+        <Input
+          onBlur={(e) => handleStringValueChange("fip_type", e.target)}
+          defaultValue={zid_metadata.fip_type}
+          disabled={zid_metadata.github_sync_enabled}
+        />
+      </Box>
+
+      <Box sx={{ mb: [3] }}>
+        <Text sx={{ mb: [2] }}>FIP category</Text>
+        <Input
+          onBlur={(e) => handleStringValueChange("fip_category", e.target)}
+          defaultValue={zid_metadata.fip_category}
+          disabled={zid_metadata.github_sync_enabled}
+        />
+      </Box>
+
+      <Box sx={{ mb: [3] }}>
+        <Text sx={{ mb: [2] }}>FIP created</Text>
+        <Input
+          onBlur={(e) => handleStringValueChange("fip_created", e.target)}
+          defaultValue={zid_metadata.fip_created}
+          disabled={zid_metadata.github_sync_enabled}
         />
       </Box>
 

--- a/client/src/pages/admin/conversation-config.tsx
+++ b/client/src/pages/admin/conversation-config.tsx
@@ -16,6 +16,8 @@ import api from "../../util/api"
 import Url from "../../util/url"
 import { RootState } from "../../util/types"
 
+const FIP_REPO_OWNER = process.env.FIP_REPO_OWNER;
+const FIP_REPO_NAME = process.env.FIP_REPO_NAME;
 
 const Input = (props: ComponentProps<"input">) =>
   <input
@@ -113,6 +115,9 @@ const ConversationConfig = ({ dispatch, zid_metadata, error }) => {
       >
         Configure
       </Heading>
+
+      Conversation for PR <a href={`https://github.com/${FIP_REPO_OWNER}/${FIP_REPO_NAME}/pull/${zid_metadata.github_pr_id}`}>#{zid_metadata.github_pr_id}</a>
+
       <Box sx={{ mb: [4] }}>{error ? <Text>Error Saving</Text> : null}</Box>
 
       <CheckboxField

--- a/client/src/pages/admin/conversation-config.tsx
+++ b/client/src/pages/admin/conversation-config.tsx
@@ -17,21 +17,21 @@ import ComponentHelpers from "../../util/component-helpers"
 import { RootState } from "../../util/types"
 
 const ConversationConfig: React.FC<{
-  dispatch: Function
+  dispatch: Function;
   zid_metadata: {
-    conversation_id: string
-    topic: string // actually: title
-    description: string // actually: intro text
-    survey_caption: string
-    postsurvey: string
-    postsurvey_limit: string
-    postsurvey_submissions: string
-    postsurvey_redirect: string
-    is_owner: boolean
-    is_mod: boolean
-  }
-  error: string
-  loading: boolean
+    conversation_id: string;
+    topic: string; // actually: title
+    description: string; // actually: intro text
+    survey_caption: string;
+    postsurvey: string;
+    postsurvey_limit: string;
+    postsurvey_submissions: string;
+    postsurvey_redirect: string;
+    is_owner: boolean;
+    is_mod: boolean;
+  };
+  error: string;
+  loading: boolean;
 }> = ({ dispatch, zid_metadata, error, loading }) => {
   // {
   //    const reportsPromise = api.get("/api/v3/reports", {
@@ -108,9 +108,11 @@ const ConversationConfig: React.FC<{
       </Heading>
       <Box sx={{ mb: [4] }}>{error ? <Text>Error Saving</Text> : null}</Box>
 
-      <CheckboxField field="is_active" label="Conversation is open">
-        Uncheck to disable voting
-      </CheckboxField>
+      <CheckboxField
+        field="is_active"
+        label="Conversation is open"
+        subtitle="Uncheck to disable voting"
+      />
 
       <Box sx={{ mt: [4], mb: [4] }}>
         <Link sx={{ variant: "styles.a" }} to={"/c/" + zid_metadata.conversation_id}>
@@ -135,9 +137,11 @@ const ConversationConfig: React.FC<{
         modify the source pull request, or disable syncing by unchecking the box below.
       </Box>
 
-      <CheckboxField field="github_sync_enabled" label="Enable GitHub sync">
-        Uncheck in order to disable syncing
-      </CheckboxField>
+      <CheckboxField
+        field="github_sync_enabled"
+        label="Enable GitHub sync"
+        subtitle="Uncheck in order to disable syncing"
+      />
 
       <Box sx={{ mb: [3] }}>
         <Text sx={{ mb: [2] }}>Title</Text>
@@ -292,17 +296,25 @@ const ConversationConfig: React.FC<{
         Permissions
       </Heading>
 
-      <CheckboxField field="write_type" label="Enable comments" isIntegerBool>
-        Participants can write their own cards (Recommended: ON)
-      </CheckboxField>
+      <CheckboxField
+        field="write_type"
+        label="Enable comments"
+        subtitle="Participants can write their own cards (Recommended: ON)"
+        isIntegerBool
+      />
 
-      <CheckboxField field="auth_needed_to_write" label="Email required for responses">
-        Require an email to submit comments (Recommended: OFF)
-      </CheckboxField>
+      <CheckboxField
+        field="auth_needed_to_write"
+        label="Email required for responses"
+        subtitle="Require an email to submit comments (Recommended: OFF)"
+      />
 
-      <CheckboxField field="strict_moderation" label="Moderation required for responses">
-        Require moderators to approve submitted comments before voters can see them
-      </CheckboxField>
+
+      <CheckboxField
+        field="strict_moderation"
+        label="Moderation required for responses"
+        subtitle="Require moderators to approve submitted comments before voters can see them"
+      />
 
       {/*
         <CheckboxField
@@ -324,7 +336,7 @@ const ConversationConfig: React.FC<{
         <CheckboxField field="auth_needed_to_vote" label="Require Auth to Vote">
           Participants cannot vote without first connecting either Facebook or Twitter
         </CheckboxField>
-         */}
+          */}
 
       <Heading as="h3" sx={{ mt: 5, mb: 4 }}>
         Embed
@@ -350,9 +362,11 @@ const ConversationConfig: React.FC<{
           </pre>
         </Box>
 
-        <CheckboxField field="importance_enabled" label="Show importance on embeds">
-          Show "This comment is important" checkbox on the embed interface
-        </CheckboxField>
+        <CheckboxField
+          field="importance_enabled"
+          label="Show importance on embeds"
+          subtitle={`Show "This comment is important" checkbox on the embed interface`}
+        />
       </Box>
 
       <Heading as="h3" sx={{ mt: 5, mb: 4 }}>

--- a/client/src/pages/admin/index.tsx
+++ b/client/src/pages/admin/index.tsx
@@ -20,7 +20,7 @@ class ConversationAdminContainer extends React.Component<
   {
     dispatch: Function
     match: { url: string; path: string; params: { conversation_id: string } }
-    zid_metadata: { is_mod: boolean }
+    zid_metadata: any
     location: UrlObject
   },
   {}

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -7,7 +7,6 @@ import { Heading, Box, Flex, Text, Button, jsx } from "theme-ui"
 import { Conversation, RootState } from "../util/types"
 import { populateConversationsStore } from "../actions"
 import remarkGfm from "remark-gfm"
-import remarkFrontMatter from "remark-frontmatter"
 import ReactMarkdown from "react-markdown"
 import { Frontmatter } from "./Frontmatter"
 import Survey from "./survey"
@@ -171,7 +170,7 @@ const Dashboard: React.FC<{ user?: any; selectedConversationId: string | null }>
                       <ReactMarkdown
                         children={selectedConversation.description}
                         skipHtml={true}
-                        remarkPlugins={[remarkGfm, [remarkFrontMatter, {type: "yaml", marker: "-"}]]}
+                        remarkPlugins={[remarkGfm]}
                         linkTarget="_blank"
                       />
                     </Box>

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -11,6 +11,9 @@ var BundleAnalyzerPlugin = require("webpack-bundle-analyzer").BundleAnalyzerPlug
 var mri = require("mri")
 var glob = require("glob")
 var fs = require("fs")
+var dotenv = require('dotenv')
+
+dotenv.config()
 
 // CLI commands for deploying built artefact.
 var argv = process.argv.slice(2)
@@ -61,11 +64,18 @@ module.exports = (env, options) => {
         inject: "body",
         templateParameters: {
           enableTwitterWidgets: enableTwitterWidgets,
-          fbAppId: fbAppId,
+          fbAppId
         },
       }),
       new webpack.DefinePlugin({
-        "process.env.FB_APP_ID": JSON.stringify(fbAppId),
+        "process.env": {
+          NODE_ENV: JSON.stringify(options.mode),
+          ENABLE_TWITTER_WIDGETS: JSON.stringify(enableTwitterWidgets),
+          FB_APP_ID: JSON.stringify(fbAppId),
+          FIP_REPO_OWNER: JSON.stringify(process.env.FIP_REPO_OWNER),
+          FIP_REPO_NAME: JSON.stringify(process.env.FIP_REPO_NAME),
+          EMBED_SERVICE_HOSTNAME: JSON.stringify(embedServiceHostname),
+        },
       }),
       // Only run analyzer when specified in flag.
       ...(cliArgs.analyze ? [new BundleAnalyzerPlugin({ defaultSizes: "gzip" })] : []),

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
         "compression-webpack-plugin": "~7.1.2",
         "copy-webpack-plugin": "~9.0.1",
         "css-loader": "^6.8.1",
+        "dotenv": "^16.3.1",
         "eslint": "~7.20.0",
         "eslint-config-prettier": "~8.1.0",
         "eslint-config-standard": "~16.0.2",
@@ -7309,6 +7310,17 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/duplexer": {
@@ -20623,13 +20635,6 @@
         "node": ">=0.3.1"
       }
     },
-    "server/node_modules/dotenv": {
-      "version": "16.0.3",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "server/node_modules/duplexify": {
       "version": "3.7.1",
       "license": "MIT",
@@ -28413,6 +28418,11 @@
         "tslib": "^2.0.3"
       }
     },
+    "dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ=="
+    },
     "duplexer": {
       "version": "0.1.2",
       "dev": true
@@ -31240,6 +31250,7 @@
         "d3-scale": "~3.2.3",
         "d3-scale-chromatic": "~1.1.1",
         "d3-voronoi": "^1.1.4",
+        "dotenv": "^16.3.1",
         "eslint": "~7.20.0",
         "eslint-config-prettier": "~8.1.0",
         "eslint-config-standard": "~16.0.2",
@@ -33100,9 +33111,6 @@
           "dev": true,
           "optional": true,
           "peer": true
-        },
-        "dotenv": {
-          "version": "16.0.3"
         },
         "duplexify": {
           "version": "3.7.1",

--- a/server/app.ts
+++ b/server/app.ts
@@ -919,6 +919,7 @@ app.put(
   want("is_anon", getBool, assignToP),
   want("is_draft", getBool, assignToP, false),
   want("is_data_open", getBool, assignToP, false),
+  want("github_sync_enabled", getBool, assignToP, true),
   want("owner_sees_participation_stats", getBool, assignToP, false),
   want("profanity_filter", getBool, assignToP),
   want("short_url", getBool, assignToP, false),

--- a/server/app.ts
+++ b/server/app.ts
@@ -927,6 +927,16 @@ app.put(
   want("strict_moderation", getBool, assignToP),
   want("topic", getOptionalStringLimitLength(400), assignToP),
   want("description", getOptionalStringLimitLength(500000), assignToP),
+
+  // FIP fields
+  want("fip_title", getOptionalStringLimitLength(500000), assignToP),
+  want("fip_author", getOptionalStringLimitLength(500000), assignToP),
+  want("fip_discussions_to", getOptionalStringLimitLength(500000), assignToP),
+  want("fip_status", getOptionalStringLimitLength(500000), assignToP),
+  want("fip_type", getOptionalStringLimitLength(500000), assignToP),
+  want("fip_category", getOptionalStringLimitLength(500000), assignToP),
+  want("fip_created", getOptionalStringLimitLength(500000), assignToP),
+
   want("survey_caption", getOptionalStringLimitLength(1024), assignToP, ""),
   want("postsurvey", getOptionalStringLimitLength(5000), assignToP, ""),
   want("postsurvey_limit", getInt, assignToP, null),

--- a/server/postgres/migrations/000020_add_github_sync_enabled_column.sql
+++ b/server/postgres/migrations/000020_add_github_sync_enabled_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE conversations ADD COLUMN github_sync_enabled boolean NOT NULL DEFAULT true;

--- a/server/src/d.ts
+++ b/server/src/d.ts
@@ -124,6 +124,7 @@ export type ConversationType = {
   is_anon?: any;
   is_draft?: any;
   is_data_open?: any;
+  github_sync_enabled?: any;
   profanity_filter?: any;
   spam_filter?: any;
   strict_moderation?: any;

--- a/server/src/d.ts
+++ b/server/src/d.ts
@@ -125,6 +125,13 @@ export type ConversationType = {
   is_draft?: any;
   is_data_open?: any;
   github_sync_enabled?: any;
+  fip_title?: any;
+  fip_author?: any;
+  fip_discussions_to?: any;
+  fip_status?: any;
+  fip_type?: any;
+  fip_category?: any;
+  fip_created?: any;
   profanity_filter?: any;
   spam_filter?: any;
   strict_moderation?: any;

--- a/server/src/db/sql.ts
+++ b/server/src/db/sql.ts
@@ -18,6 +18,13 @@ const sql_conversations: any = sql.define({
     "is_public", // TODO remove this column
     "is_data_open",
     "github_sync_enabled",
+    "fip_author",
+    "fip_discussions_to",
+    "fip_status",
+    "fip_type",
+    "fip_category",
+    "fip_created",
+    "fip_title",
     "profanity_filter",
     "spam_filter",
     "strict_moderation",

--- a/server/src/db/sql.ts
+++ b/server/src/db/sql.ts
@@ -17,6 +17,7 @@ const sql_conversations: any = sql.define({
     "is_draft",
     "is_public", // TODO remove this column
     "is_data_open",
+    "github_sync_enabled",
     "profanity_filter",
     "spam_filter",
     "strict_moderation",

--- a/server/src/handlers/github_sync.ts
+++ b/server/src/handlers/github_sync.ts
@@ -291,6 +291,11 @@ export async function handle_POST_github_sync(req: Request, res: Response) {
       // check if there is a conversation with this PR id already
       const existingConversation = await getConversationByPrId(pull.number);
       if(existingConversation) {
+        if(!existingConversation.github_sync_enabled) {
+          console.log(`github sync is disabled for PR ${pull.number}, skipping`);
+          continue;
+        }
+
         console.log(`conversation with PR ${pull.number} already exists, updating`);
 
         // update

--- a/server/src/handlers/github_sync.ts
+++ b/server/src/handlers/github_sync.ts
@@ -182,7 +182,9 @@ async function getFipFromPR(
 
   // try to extract frontmatter
 
-  const frontmatterSource = content.split("---")[1];
+  const contentParts = content.split("---");
+  const frontmatterSource = contentParts[1];
+  const description = contentParts[2];
 
   let frontmatterData;
   try {
@@ -193,7 +195,7 @@ async function getFipFromPR(
   }
 
   return {
-    description: content,
+    description,
     topic: filename.split(".")[0],
     fip_title: frontmatterData.title,
     fip_author: frontmatterData.author,

--- a/server/src/handlers/queries.ts
+++ b/server/src/handlers/queries.ts
@@ -63,8 +63,8 @@ export async function getUserUidByGithubUsername(githubUsername: string): Promis
   return rows[0];
 }
 
-export async function getConversationByPrId(prId: number): Promise<PrFields | undefined> {
-  const query = `SELECT ${PR_FIELDS.join(", ")} FROM conversations WHERE github_pr_id = $1;`;
+export async function getConversationByPrId(prId: number): Promise<PrFields & {github_sync_enabled: boolean} | undefined> {
+  const query = `SELECT ${[...PR_FIELDS, "github_sync_enabled"].join(", ")} FROM conversations WHERE github_pr_id = $1;`;
   const rows = await queryP(query, [prId]);
   return rows[0]
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -7096,6 +7096,7 @@ function handle_PUT_conversations(
       is_anon: any;
       is_draft: any;
       is_data_open: any;
+      github_sync_enabled: any;
       profanity_filter: any;
       spam_filter: any;
       strict_moderation: any;
@@ -7153,6 +7154,9 @@ function handle_PUT_conversations(
       }
       if (!_.isUndefined(req.p.is_data_open)) {
         fields.is_data_open = req.p.is_data_open;
+      }
+      if (!_.isUndefined(req.p.github_sync_enabled)) {
+        fields.github_sync_enabled = req.p.github_sync_enabled;
       }
       if (!_.isUndefined(req.p.profanity_filter)) {
         fields.profanity_filter = req.p.profanity_filter;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -7097,6 +7097,13 @@ function handle_PUT_conversations(
       is_draft: any;
       is_data_open: any;
       github_sync_enabled: any;
+      fip_author: any;
+      fip_discussions_to: any;
+      fip_status: any;
+      fip_type: any;
+      fip_category: any;
+      fip_created: any;
+      fip_title: any;
       profanity_filter: any;
       spam_filter: any;
       strict_moderation: any;
@@ -7158,6 +7165,34 @@ function handle_PUT_conversations(
       if (!_.isUndefined(req.p.github_sync_enabled)) {
         fields.github_sync_enabled = req.p.github_sync_enabled;
       }
+
+      // FIP fields
+      // we only want to update these if github_sync_enabled is false
+      // this is because if github sync was to be enabled, then the FIP fields would be overwritten
+      if(req.p.github_sync_enabled == false) {
+        if (!_.isUndefined(req.p.fip_title)) {
+          fields.fip_title = req.p.fip_title;
+        }
+        if (!_.isUndefined(req.p.fip_author)) {
+          fields.fip_author = req.p.fip_author;
+        }
+        if (!_.isUndefined(req.p.fip_discussions_to)) {
+          fields.fip_discussions_to = req.p.fip_discussions_to;
+        }
+        if (!_.isUndefined(req.p.fip_status)) {
+          fields.fip_status = req.p.fip_status;
+        }
+        if (!_.isUndefined(req.p.fip_type)) {
+          fields.fip_type = req.p.fip_type;
+        }
+        if (!_.isUndefined(req.p.fip_category)) {
+          fields.fip_category = req.p.fip_category;
+        }
+        if (!_.isUndefined(req.p.fip_created)) {
+          fields.fip_created = req.p.fip_created;
+        }
+      }
+
       if (!_.isUndefined(req.p.profanity_filter)) {
         fields.profanity_filter = req.p.profanity_filter;
       }


### PR DESCRIPTION
This PR updates the "Configure" page for the conversations so that:
- syncing can be enabled/disabled for a given conversation
- if syncing is disabled, admins/owners can manually modify the fields that have been synced from GitHub

There are some miscellaneous fixes in here as well, such as:
- https://github.com/canvasxyz/metropolis/commit/882b15cc1b0589bea7cfb237c14861cd7550bc2d use the `@typescript-eslint/parser` parser in eslint on the client, the babel-eslint parser flags some valid typescript syntax as being invalid
- use dotenv to inject environment variables into the client, this is the same method that we are using on the backend