### PR TITLE
Use GitHub user id to identify GitHub users

### DIFF
--- a/server/postgres/migrations/000025_add_github_user_id_to_users.sql
+++ b/server/postgres/migrations/000025_add_github_user_id_to_users.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN github_user_id integer;

--- a/server/src/handlers/github_auth.ts
+++ b/server/src/handlers/github_auth.ts
@@ -5,7 +5,7 @@ import { createOAuthUserAuth } from "@octokit/auth-oauth-user";
 import { startSession } from "../session";
 import cookies from "../utils/cookies";
 import fail from "../utils/fail";
-import { getOrCreateUserWithGithubUsername } from "./queries";
+import { updateOrCreateGitHubUser } from "./queries";
 
 /** api handlers for performing a github authentication flow */
 
@@ -41,7 +41,7 @@ async function handleGithubOauthCallback(req: { p: {uid?: any; code: string; des
 
   // get the github username that is associated with the token
   const {
-    data: { login: githubUsername },
+    data: { login: githubUsername, id: githubUserId, email: githubUserEmail },
   } = await octokit.request("GET /user");
 
   if(!githubUsername) {
@@ -50,7 +50,11 @@ async function handleGithubOauthCallback(req: { p: {uid?: any; code: string; des
 
   // the user is now authenticated
 
-  const {uid} = await getOrCreateUserWithGithubUsername(githubUsername);
+  const {uid} = await updateOrCreateGitHubUser({
+    username: githubUsername,
+    id: githubUserId,
+    email: githubUserEmail
+  });
 
   const token = await startSession(uid);
 

--- a/server/src/handlers/queries.ts
+++ b/server/src/handlers/queries.ts
@@ -67,11 +67,10 @@ export async function createUserWithGithubUsername(
 ): Promise<{ uid: number }> {
   const createQuery =
     "insert into users " +
-    "(email, hname, zinvite, is_owner) VALUES " +
+    "(github_username, hname, zinvite, is_owner) VALUES " +
     "($1, $2, $3, $4) " +
     "returning uid;";
-  const email = `github: ${githubUsername}`;
-  const vals = [email, githubUsername, null, true];
+  const vals = [githubUsername, githubUsername, null, true];
   const createRes = await queryP(createQuery, vals);
   return createRes[0];
 }
@@ -79,11 +78,11 @@ export async function createUserWithGithubUsername(
 export async function getUserUidByGithubUsername(
   githubUsername: string,
 ): Promise<{ uid: number } | undefined> {
-  const query = "SELECT uid FROM users WHERE email = $1";
+  const query = "SELECT uid FROM users WHERE github_username = $1";
   // TODO: this is a hack, we should have more semantically meaningful columns
-  const rows = await queryP(query, [`github: ${githubUsername}`]);
+  const rows = await queryP(query, [githubUsername]);
   if (rows.length > 1) {
-    throw Error("polis_more_than_one_user_with_same_email");
+    throw Error("polis_more_than_one_user_with_same_github_username");
   }
   return rows[0];
 }


### PR DESCRIPTION
This PR makes changes to the way we store information about users who have logged in with GitHub.

- Store the user's GitHub id in`github_user_id`, when syncing this is used as a key. This value never changes. This means that when a user changes their GitHub username, we can keep track of this change.
- Try to get the email for a GitHub user - this is the email address that is displayed on their public profile. This is optional, so we shouldn't assume this value exists.

Before we deploy this on an existing instance, we need to perform a few data migrations to make sure that two conditions are satisfied:

1. We should only be using the `github_username` column to store a user's GitHub username, not `hname` or `email`
2. Every user entry that is associated with a GitHub account should have a `github_user_id` value

Data migrations:

set github_user_name to be hname for github users
`UPDATE users SET github_username = hname WHERE email LIKE 'github: %';`

eyeball check that all users now have github_user_name values
`SELECT * FROM users;`

for all users that have a github_user_name, set email to null
`UPDATE users SET email = null WHERE github_username <> '';`

for all users that have a github_user_name, set hname to null
`UPDATE users SET hname = null WHERE github_username <> '';`

now we are just using github_user_name as a "screen name"

Next, for each user we should look up the GitHub ID. If there are only a few users we can get away with using a tool like https://caius.github.io/github_id/ , otherwise we should write a script that makes a bunch of calls to the GitHub API to retrieve this value. We then need to write this value to the database using a query like:

`UPDATE users SET github_user_id = <github user id> WHERE github_username = <github username;`