### PR TITLE
Save `is_repo_collaborator`

### DIFF
--- a/server/postgres/migrations/000026_add_is_repo_collaborator_to_users.sql
+++ b/server/postgres/migrations/000026_add_is_repo_collaborator_to_users.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN is_repo_collaborator boolean NOT NULL DEFAULT false;

--- a/server/src/handlers/api_wrappers.ts
+++ b/server/src/handlers/api_wrappers.ts
@@ -77,3 +77,28 @@ export async function getOctoKitForInstallation() {
     },
   });
 }
+
+export async function getRepoCollaborators() {
+  const installationOctokit = await getOctoKitForInstallation();
+
+  if (!process.env.FIP_REPO_OWNER) {
+    throw Error("FIP_REPO_OWNER not set");
+  }
+
+  if (!process.env.FIP_REPO_NAME) {
+    throw Error("FIP_REPO_NAME not set");
+  }
+
+  const { data } = await installationOctokit.request(
+    "GET /repos/{owner}/{repo}/collaborators",
+    {
+      repo: process.env.FIP_REPO_NAME,
+      owner: process.env.FIP_REPO_OWNER,
+      headers: {
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+
+  return data;
+}

--- a/server/src/handlers/github_sync.ts
+++ b/server/src/handlers/github_sync.ts
@@ -12,6 +12,7 @@ import Config from "../config";
 import {
   getGraphqlForInstallation,
   getOctoKitForInstallation,
+  getRepoCollaborators,
 } from "./api_wrappers";
 import {
   FipFields,
@@ -315,6 +316,9 @@ export async function handle_POST_github_sync(req: Request, res: Response) {
       `Found ${existingFipFilenames.size} FIPs in master, ${pulls.length} open PRs`,
     );
 
+    const repoCollaborators = await getRepoCollaborators();
+    const repoCollaboratorIds = new Set(repoCollaborators.map((c) => c.id))
+
     for (const pull of pulls) {
       if(!pull.user) {
         continue;
@@ -335,7 +339,8 @@ export async function handle_POST_github_sync(req: Request, res: Response) {
       const { uid } = await updateOrCreateGitHubUser({
         id: pull.user.id,
         email,
-        username: pull.user.login
+        username: pull.user.login,
+        isRepoCollaborator: repoCollaboratorIds.has(pull.user.id) || pull.user.login === process.env.FIP_REPO_OWNER,
       });
 
       const prFields: PrFields = {

--- a/server/src/handlers/queries.ts
+++ b/server/src/handlers/queries.ts
@@ -4,6 +4,7 @@ export type GitHubUserData = {
   id: number;
   username: string;
   email: string | null;
+  isRepoCollaborator: boolean;
 }
 
 /** database queries used by the github integrations */
@@ -73,10 +74,16 @@ export async function createGitHubUser(
 ): Promise<{ uid: number }> {
   const createQuery =
     "insert into users " +
-    "(github_user_id, github_username, github_email, is_owner) VALUES " +
-    "($1, $2, $3, $4) " +
+    "(github_user_id, github_username, github_email, is_repo_collaborator, is_owner) VALUES " +
+    "($1, $2, $3, $4, $5) " +
     "returning uid;";
-  const vals = [githubUserData.id, githubUserData.username, githubUserData.email, true];
+  const vals = [
+    githubUserData.id,
+    githubUserData.username,
+    githubUserData.email,
+    githubUserData.isRepoCollaborator,
+    true
+  ];
   const createRes = await queryP(createQuery, vals);
   return createRes[0];
 }
@@ -85,9 +92,14 @@ export async function updateGitHubUserData(
   githubUserData: GitHubUserData,
 ): Promise<{ uid: number }> {
   const createQuery =
-    "UPDATE users SET github_username = $1, github_email = $2 WHERE github_user_id = $3" +
+    "UPDATE users SET github_username = $1, github_email = $2, is_repo_collaborator = $3 WHERE github_user_id = $4" +
     "returning uid;";
-  const vals = [githubUserData.username, githubUserData.email, githubUserData.id];
+  const vals = [
+    githubUserData.username,
+    githubUserData.email,
+    githubUserData.isRepoCollaborator,
+    githubUserData.id
+  ];
   const updateRes = await queryP(createQuery, vals);
   return updateRes[0];
 }


### PR DESCRIPTION
Base PR: https://github.com/canvasxyz/metropolis/pull/12

It implement parts of https://github.com/canvasxyz/metropolis/issues/10

This pull request adds a new boolean column `is_repo_collaborator` to the `users` table, which record whether a user's GitHub account is an owner or a collaborator of the proposals repository. This field is updated whenever a user logs in using GitHub auth, or when we run GitHub sync. The list of collaborators comes from the `GET /repos/{owner}/{repo}/collaborators` endpoint on the GitHub REST API.

This PR doesn't change how our permissions behave, it just saves the information in the database. 