### PR TITLE
Display the link to the proposal PR using `github_pr_url`

### DIFF
--- a/client/src/pages/Frontmatter.tsx
+++ b/client/src/pages/Frontmatter.tsx
@@ -40,13 +40,15 @@ export const Frontmatter = ({ conversation }: FrontmatterProps) => {
                   </td>
                   <td className="border">
                     {valueFieldName === "fip_title" ? (
-                      <Link
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        href={`https://github.com/${conversation.github_repo_owner}/${conversation.github_repo_name}/pull/${conversation.github_pr_id}/files`}
-                      >
-                        {conversation[valueFieldName]}
-                      </Link>
+                      conversation.github_pr_url !== null ? (
+                        <Link
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          href={conversation.github_pr_url}
+                        >
+                          {conversation[valueFieldName]}
+                        </Link>
+                      ) : conversation[valueFieldName]
                     ) : valueFieldName === "fip_discussions_to" ? (
                       <Link
                         href={conversation[valueFieldName]}

--- a/client/src/util/types.tsx
+++ b/client/src/util/types.tsx
@@ -35,6 +35,7 @@ export type Conversation = {
   github_pr_id: string
   github_pr_title: string
   github_pr_submitter: string
+  github_pr_url: string | null
   fip_number: number
   fip_title: string
   fip_author: string

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -7725,6 +7725,12 @@ async function handle_GET_conversations(
 
     conv.is_mod = uid && isAdministrator(uid);
 
+    if(conv.github_pr_id !== null) {
+      conv.github_pr_url = `https://github.com/${process.env.FIP_REPO_OWNER}/${process.env.FIP_REPO_NAME}/pull/${conv.github_pr_id}/files`;
+    } else {
+      conv.github_pr_url = null;
+    }
+
     // Make sure zid is not exposed
     delete conv.zid;
 


### PR DESCRIPTION
This PR modifies the `GET /api/v3/conversations` endpoint to return a new field `github_pr_url` which is the URL of the pull request for the conversation proposal, if there is one. This is the URL of the PR on GitHub, using the FIP repo owner, FIP repo name and pull request number values. This PR also modifies the frontend so that it uses this value when displaying the link to the PR.