### PR TITLE
Fix bug with SignOut component

### DIFF
--- a/client/src/pages/landing/signout.tsx
+++ b/client/src/pages/landing/signout.tsx
@@ -1,26 +1,24 @@
-import React from "react"
+import React, { useEffect } from "react"
 import { Heading } from "theme-ui"
 
 import { doSignout } from "../../actions"
-import { AppDispatch } from "../../store"
+import { useAppDispatch } from "../../hooks"
 
-class SignOut extends React.Component<{ dispatch: AppDispatch }, {}> {
-  static propTypes: { dispatch: AppDispatch }
+function SignOut() {
+  const dispatch = useAppDispatch()
 
-  componentDidMount() {
-    this.props.dispatch(doSignout("/"))
-  }
+  useEffect(() => {
+    dispatch(doSignout("/"))
+  }, [dispatch])
 
-  render() {
-    return (
-      <>
-        <Heading as="h1" sx={{ my: [4, null, 5], fontSize: [6] }}>
-          Signing Out...
-        </Heading>
-        <p>Please wait a second to be signed out.</p>
-      </>
-    )
-  }
+  return (
+    <>
+      <Heading as="h1" sx={{ my: [4, null, 5], fontSize: [6] }}>
+        Signing Out...
+      </Heading>
+      <p>Please wait a second to be signed out.</p>
+    </>
+  )
 }
 
 


### PR DESCRIPTION
This was caused by this commit removing the `connect` function call from the `SignOut` class. https://github.com/canvasxyz/metropolis/commit/142e263f50887b20696366761e3102816e27e817#diff-bfd70249950b1dfc9882e91de16a924caf1a389a449da8acd6b7c43c826c47eaL1

In addition to passing in data from the reducers, `connect` also provides `dispatch` function, so when it was removed there was a runtime error... This PR updates the code to use `useAppDispatch` to get the dispatch function inside a functional component.

This PR has been QA tested - I logged in with a user, navigated to the Account page and clicked "Sign out", which successfully signed the user out.