### PR TITLE
Rjwebb/show account link in dashboard

### DIFF
--- a/client/src/pages/account.tsx
+++ b/client/src/pages/account.tsx
@@ -1,21 +1,15 @@
 import React from "react"
-import PropTypes from "prop-types"
-import { ConnectedProps, connect } from "react-redux"
 import { Box, Heading } from "theme-ui"
 
-import { User } from "../util/types"
 import Spinner from "../components/spinner"
-import { RootState } from "../store"
+import { useAppSelector } from "../hooks"
 
-const connector = connect((state: RootState) => state.user)
-type PropsFromRedux = ConnectedProps<typeof connector>
 
-class Account extends React.Component<PropsFromRedux> {
-  static propTypes: {
-    user: object
-  }
+function Account(){
+  const {user, isLoggedIn} = useAppSelector((state) => state.user)
 
-  buildAccountMarkup() {
+  if(isLoggedIn){
+    const nameToDisplay = user.hname || user.email || user.githubUsername
     return (
       <Box>
         <Heading
@@ -29,37 +23,27 @@ class Account extends React.Component<PropsFromRedux> {
         >
           Account
         </Heading>
-        <p>Hi {this.props.user.hname.split(" ")[0]}!</p>
+        <p>Hi {nameToDisplay}!</p>
         <Box>
-          <p>Name: {this.props.user.hname}</p>
-          <p>Email: {this.props.user.email || "--"}</p>
-          <p>
-            Social:{" "}
-            {!this.props.user.hasFacebook && !this.props.user.hasTwitter
-              ? "No social accounts connected"
-              : ""}
-          </p>
-          <p>
-            {this.props.user.hasFacebook ? <p>Facebook is connected</p> : ""}
-            {this.props.user.hasTwitter ? <p>Twitter is connected</p> : ""}
-          </p>
+          {
+            user.githubUserId ? (
+              <p>
+                GitHub account: <a
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  href={`https://github.com/${user.githubUsername}`}
+                >{user.githubUsername}</a>
+              </p>
+            ) : (
+              <p>Email: {user.email || "--"}</p>
+            )
+          }
         </Box>
       </Box>
     )
-  }
-
-  render() {
-    return <div>{this.props.user.hname ? this.buildAccountMarkup() : <Spinner />}</div>
+  } else {
+    return <Spinner />
   }
 }
 
-Account.propTypes = {
-  user: PropTypes.shape({
-    hname: PropTypes.string,
-    email: PropTypes.string,
-    hasFacebook: PropTypes.bool,
-    hasTwitter: PropTypes.bool,
-  }),
-}
-
-export default connector(Account)
+export default Account

--- a/client/src/pages/dashboard/conversation.tsx
+++ b/client/src/pages/dashboard/conversation.tsx
@@ -26,7 +26,7 @@ export const DashboardConversation = ({ conversation, zid_metadata }) => {
   }, [zid_metadata.conversation_id])
 
   return (
-    <Box sx={{position: "relative"}}>
+    <Box>
       {zid_metadata.is_owner && (
         <Button
           variant="outlineSecondary"

--- a/client/src/pages/dashboard/index.tsx
+++ b/client/src/pages/dashboard/index.tsx
@@ -281,7 +281,19 @@ const Dashboard = ({ user, selectedConversationId }: DashboardProps) => {
             )}
           </Box>
         </Box>
-        <Box sx={{ overflowY: "scroll", flex: 1 }}>
+        <Box sx={{ overflowY: "scroll", flex: 1, position: "relative" }}>
+          <Button
+            variant="outlineSecondary"
+            sx={{
+              position: "absolute",
+              top: [3],
+              right: [4],
+              alignItems: "center",
+            }}
+            onClick={() => hist.push(`/account`)}
+          >
+            <Text>Account</Text>
+          </Button>
           {selectedConversation ? (
             <DashboardConversation
               conversation={selectedConversation}

--- a/client/src/pages/dashboard/index.tsx
+++ b/client/src/pages/dashboard/index.tsx
@@ -3,7 +3,7 @@
 import { Fragment, useCallback, useEffect, useState } from "react"
 import { useLocalStorage } from "usehooks-ts"
 import { Link as RouterLink, useHistory } from "react-router-dom"
-import { Heading, Box, Flex, Text, Button, jsx } from "theme-ui"
+import { Heading, Box, Flex, Link, Text, Button, jsx } from "theme-ui"
 import { toast } from "react-hot-toast"
 
 import api from "../../util/api"
@@ -80,7 +80,7 @@ type DashboardProps = {
   selectedConversationId: string | null
 }
 
-const Dashboard = ({ user, selectedConversationId }: DashboardProps) => {
+const Dashboard = ({ selectedConversationId }: DashboardProps) => {
   const dispatch = useAppDispatch()
 
   useEffect(() => {
@@ -90,6 +90,8 @@ const Dashboard = ({ user, selectedConversationId }: DashboardProps) => {
   useEffect(() => {
     dispatch(populateConversationsStore())
   }, [])
+
+  const {user, isLoggedIn} = useAppSelector((state: RootState) => state.user)
 
   const hist = useHistory()
   const data = useAppSelector((state: RootState) => state.conversations)
@@ -282,18 +284,33 @@ const Dashboard = ({ user, selectedConversationId }: DashboardProps) => {
           </Box>
         </Box>
         <Box sx={{ overflowY: "scroll", flex: 1, position: "relative" }}>
-          <Button
-            variant="outlineSecondary"
-            sx={{
-              position: "absolute",
-              top: [3],
-              right: [4],
-              alignItems: "center",
-            }}
-            onClick={() => hist.push(`/account`)}
-          >
-            <Text>Account</Text>
-          </Button>
+          {
+            user && isLoggedIn
+            ? <Button
+                variant="outlineSecondary"
+                sx={{
+                  position: "absolute",
+                  top: [3],
+                  right: [4],
+                  alignItems: "center",
+                }}
+                onClick={() => hist.push(`/account`)}
+              >
+                <Text>Account</Text>
+              </Button>
+            : <Link
+                variant="links.buttonBlack"
+                sx={{
+                  position: "absolute",
+                  top: [3],
+                  right: [4],
+                  alignItems: "center",
+                }}
+                href={`/api/v3/github_oauth_init?dest=${window.location.href}`}
+              >
+                Github Login
+              </Link>
+          }
           {selectedConversation ? (
             <DashboardConversation
               conversation={selectedConversation}

--- a/client/src/pages/dashboard/index.tsx
+++ b/client/src/pages/dashboard/index.tsx
@@ -14,6 +14,7 @@ import Spinner from "../../components/spinner"
 import { DashboardConversation } from "./conversation"
 import { RootState } from "../../store"
 import { useAppDispatch, useAppSelector } from "../../hooks"
+import { DashboardUserButton } from "./user_button"
 
 const sidebarCollapsibleHeaderStyle = {
   fontSize: "15px",
@@ -284,34 +285,7 @@ const Dashboard = ({ selectedConversationId }: DashboardProps) => {
           </Box>
         </Box>
         <Box sx={{ overflowY: "scroll", flex: 1, position: "relative" }}>
-          {
-            !userIsLoading &&
-            (user && isLoggedIn
-            ? <Button
-                variant="outlineSecondary"
-                sx={{
-                  position: "absolute",
-                  top: [3],
-                  right: [4],
-                  alignItems: "center",
-                }}
-                onClick={() => hist.push(`/account`)}
-              >
-                <Text>{user.email || user.githubUsername || "View Account"}</Text>
-              </Button>
-            : <Link
-                variant="links.buttonBlack"
-                sx={{
-                  position: "absolute",
-                  top: [3],
-                  right: [4],
-                  alignItems: "center",
-                }}
-                href={`/api/v3/github_oauth_init?dest=${window.location.href}`}
-              >
-                Github Login
-              </Link>)
-          }
+          <DashboardUserButton />
           {selectedConversation ? (
             <DashboardConversation
               conversation={selectedConversation}

--- a/client/src/pages/dashboard/index.tsx
+++ b/client/src/pages/dashboard/index.tsx
@@ -296,7 +296,7 @@ const Dashboard = ({ selectedConversationId }: DashboardProps) => {
                 }}
                 onClick={() => hist.push(`/account`)}
               >
-                <Text>Account {user.email || user.githubUsername}</Text>
+                <Text>{user.email || user.githubUsername || "View Account"}</Text>
               </Button>
             : <Link
                 variant="links.buttonBlack"

--- a/client/src/pages/dashboard/index.tsx
+++ b/client/src/pages/dashboard/index.tsx
@@ -91,7 +91,7 @@ const Dashboard = ({ selectedConversationId }: DashboardProps) => {
     dispatch(populateConversationsStore())
   }, [])
 
-  const {user, isLoggedIn} = useAppSelector((state: RootState) => state.user)
+  const {user, isLoggedIn, loading: userIsLoading} = useAppSelector((state: RootState) => state.user)
 
   const hist = useHistory()
   const data = useAppSelector((state: RootState) => state.conversations)
@@ -285,7 +285,8 @@ const Dashboard = ({ selectedConversationId }: DashboardProps) => {
         </Box>
         <Box sx={{ overflowY: "scroll", flex: 1, position: "relative" }}>
           {
-            user && isLoggedIn
+            !userIsLoading &&
+            (user && isLoggedIn
             ? <Button
                 variant="outlineSecondary"
                 sx={{
@@ -309,7 +310,7 @@ const Dashboard = ({ selectedConversationId }: DashboardProps) => {
                 href={`/api/v3/github_oauth_init?dest=${window.location.href}`}
               >
                 Github Login
-              </Link>
+              </Link>)
           }
           {selectedConversation ? (
             <DashboardConversation

--- a/client/src/pages/dashboard/index.tsx
+++ b/client/src/pages/dashboard/index.tsx
@@ -296,7 +296,7 @@ const Dashboard = ({ selectedConversationId }: DashboardProps) => {
                 }}
                 onClick={() => hist.push(`/account`)}
               >
-                <Text>Account</Text>
+                <Text>Account {user.email || user.githubUsername}</Text>
               </Button>
             : <Link
                 variant="links.buttonBlack"

--- a/client/src/pages/dashboard/user_button.tsx
+++ b/client/src/pages/dashboard/user_button.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { Link, Text, Button } from "theme-ui"
+
+import { useAppSelector } from "../../hooks";
+import { RootState } from "../../store";
+import { useHistory } from "react-router-dom";
+
+export const DashboardUserButton = () => {
+  const {loading, user, isLoggedIn} = useAppSelector((state: RootState) => state.user);
+  const hist = useHistory()
+
+  if (loading) {
+    return null;
+  }
+
+  if(isLoggedIn) {
+    return <Button
+      variant="outlineSecondary"
+      sx={{
+        position: "absolute",
+        top: [3],
+        right: [4],
+        alignItems: "center",
+      }}
+      onClick={() => hist.push(`/account`)}
+    >
+      <Text>{user.email || user.githubUsername || "View Account"}</Text>
+    </Button>;
+  }
+
+  return <Link
+    variant="links.buttonBlack"
+    sx={{
+      position: "absolute",
+      top: [3],
+      right: [4],
+      alignItems: "center",
+    }}
+    href={`/api/v3/github_oauth_init?dest=${window.location.href}`}
+  >
+    Github Login
+  </Link>
+}

--- a/client/src/reducers/user.ts
+++ b/client/src/reducers/user.ts
@@ -7,7 +7,7 @@ const user = (
     loading: false,
     user: null,
     error: false,
-    isLoggedIn: false,
+    isLoggedIn: undefined,
   },
   action,
 ) => {

--- a/client/src/reducers/user.ts
+++ b/client/src/reducers/user.ts
@@ -20,7 +20,6 @@ const user = (
       return Object.assign({}, state, {
         loading: false,
         user: action.data,
-        githubUserId: action.data.githubUserId,
         isLoggedIn: !!action.data.email || !!action.data.githubUserId || !!action.data.xInfo,
         error: false,
       })

--- a/client/src/reducers/user.ts
+++ b/client/src/reducers/user.ts
@@ -7,7 +7,7 @@ const user = (
     loading: false,
     user: null,
     error: false,
-    isLoggedIn: undefined,
+    isLoggedIn: false,
   },
   action,
 ) => {

--- a/server/src/handlers/github_auth.ts
+++ b/server/src/handlers/github_auth.ts
@@ -7,6 +7,7 @@ import cookies from "../utils/cookies";
 import fail from "../utils/fail";
 import { updateOrCreateGitHubUser } from "./queries";
 import { getRepoCollaborators } from "./api_wrappers";
+import Config from "../config"
 
 /** api handlers for performing a github authentication flow */
 
@@ -16,9 +17,9 @@ export function handle_GET_github_init(
 ){
   let dest = req.p.dest
   const clientId = process.env.GH_APP_CLIENT_ID;
-  const redirectUrl = `https://github.com/login/oauth/authorize?scope=user:email&client_id=${clientId}&dest=${dest}`;
-
-  res.redirect(redirectUrl);
+  const redirectUri = `${Config.getServerUrl()}/api/v3/github_oauth_callback?dest=${dest}`;
+  const githubAuthorizeUrl = `https://github.com/login/oauth/authorize?scope=user:email&client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}`;
+  res.redirect(githubAuthorizeUrl);
 }
 
 export function handle_GET_github_oauth_callback(

--- a/server/src/user.ts
+++ b/server/src/user.ts
@@ -82,6 +82,7 @@ async function getUser(
     uid: uid,
     email: info.email,
     githubUserId: info.github_user_id,
+    githubUsername: info.github_username,
     hname: info.hname,
     hasXid: !!hasXid,
     xInfo: xInfo && xInfo[0],


### PR DESCRIPTION
This PR lets users see whether or not they are logged into Metropolis from the Dashboard. It adds a button which, if the user is logged in, shows their email or GitHub username. If the user is logged out it shows a "Github Login" button (this is the same one that we show on the front page), which lets the user log in with GitHub, it redirects back to the dashboard.

Other changes:
- return the `github_username` field in the `/users` endpoint
- remove a redundant `githubUserId` field from the `user` reducer - this is already returned inside `user.user`


<img width="757" alt="Screenshot 2023-12-07 at 3 05 02 pm" src="https://github.com/canvasxyz/metropolis/assets/457206/cdb1d573-46c7-4ca2-8ee5-da1e71a7d228">
<img width="788" alt="Screenshot 2023-12-07 at 3 04 54 pm" src="https://github.com/canvasxyz/metropolis/assets/457206/f1b85bc4-ea2e-44d6-8396-caf3dbdab5e0">
