### PR TITLE
Migrate server to Express 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5494,6 +5494,7 @@
     },
     "node_modules/body-parser": {
       "version": "1.20.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
@@ -5516,6 +5517,7 @@
     },
     "node_modules/body-parser/node_modules/bytes": {
       "version": "3.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -5523,6 +5525,7 @@
     },
     "node_modules/body-parser/node_modules/debug": {
       "version": "2.6.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -6240,6 +6243,7 @@
     },
     "node_modules/cookie": {
       "version": "0.5.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -8429,6 +8433,7 @@
       "version": "4.18.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
       "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -8502,10 +8507,12 @@
     },
     "node_modules/express/node_modules/array-flatten": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/express/node_modules/content-disposition": {
       "version": "0.5.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
@@ -8516,6 +8523,7 @@
     },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -8523,10 +8531,12 @@
     },
     "node_modules/express/node_modules/path-to-regexp": {
       "version": "0.1.7",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/express/node_modules/range-parser": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -8680,6 +8690,7 @@
     },
     "node_modules/finalhandler": {
       "version": "1.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -8696,6 +8707,7 @@
     },
     "node_modules/finalhandler/node_modules/debug": {
       "version": "2.6.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -9674,6 +9686,7 @@
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "2.0.0",
@@ -12961,6 +12974,7 @@
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -13209,7 +13223,6 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13833,6 +13846,7 @@
     },
     "node_modules/raw-body": {
       "version": "2.5.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
@@ -13846,6 +13860,7 @@
     },
     "node_modules/raw-body/node_modules/bytes": {
       "version": "3.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -15989,6 +16004,32 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/router": {
+      "version": "2.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.0.0-beta.1.tgz",
+      "integrity": "sha512-GLoYgkhAGAiwVda5nt6Qd4+5RAPuQ4WIYLlZ+mxfYICI+22gnIB3eCfmhgV8+uJNPS1/39DOYi/vdrrz0/ouKA==",
+      "dependencies": {
+        "array-flatten": "3.0.0",
+        "methods": "~1.1.2",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "3.2.0",
+        "setprototypeof": "1.2.0",
+        "utils-merge": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/router/node_modules/array-flatten": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
+      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.2.0.tgz",
+      "integrity": "sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA=="
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "dev": true,
@@ -16161,6 +16202,7 @@
     },
     "node_modules/send": {
       "version": "0.18.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -16183,6 +16225,7 @@
     },
     "node_modules/send/node_modules/debug": {
       "version": "2.6.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -16190,10 +16233,12 @@
     },
     "node_modules/send/node_modules/debug/node_modules/ms": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/send/node_modules/mime": {
       "version": "1.6.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mime": "cli.js"
@@ -16204,10 +16249,12 @@
     },
     "node_modules/send/node_modules/ms": {
       "version": "2.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/send/node_modules/range-parser": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -16391,6 +16438,7 @@
     },
     "node_modules/serve-static": {
       "version": "1.15.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "~1.0.2",
@@ -16736,6 +16784,7 @@
     },
     "node_modules/statuses": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -19245,7 +19294,7 @@
         "cookie-parser": "^1.4.6",
         "dotenv": "^16.0.3",
         "errorhandler": "^1.4.3",
-        "express": "^4.18.2",
+        "express": "^5.0.0-beta.1",
         "express-session": "^1.17.3",
         "fb": "~1.0.2",
         "http-proxy": "~1.18.1",
@@ -20423,6 +20472,11 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "server/node_modules/array-flatten": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
+      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
+    },
     "server/node_modules/arrify": {
       "version": "1.0.1",
       "license": "MIT",
@@ -20859,10 +20913,48 @@
         "node": ">= 0.8"
       }
     },
+    "server/node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "server/node_modules/content-disposition/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "server/node_modules/convert-source-map": {
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "server/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "server/node_modules/cookiejar": {
       "version": "2.1.4",
@@ -21248,6 +21340,164 @@
         "node": ">= 0.8.0"
       }
     },
+    "server/node_modules/express": {
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.0.0-beta.1.tgz",
+      "integrity": "sha512-KPtBrlZoQu2Ps0Ce/Imqtq73AB0KBJ8Gx59yZQ3pmDJU2/LhcoZETo03oSgtTQufbcLXt/WBITk/jMjl/WMyrQ==",
+      "dependencies": {
+        "accepts": "~1.3.7",
+        "array-flatten": "3.0.0",
+        "body-parser": "2.0.0-beta.1",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6",
+        "debug": "3.1.0",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "mime-types": "~2.1.34",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-is-absolute": "1.0.1",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.9.6",
+        "range-parser": "~1.2.1",
+        "router": "2.0.0-beta.1",
+        "safe-buffer": "5.2.1",
+        "send": "1.0.0-beta.1",
+        "serve-static": "2.0.0-beta.1",
+        "setprototypeof": "1.2.0",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "server/node_modules/express/node_modules/body-parser": {
+      "version": "2.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.0.0-beta.1.tgz",
+      "integrity": "sha512-I1v2bt2OdYqtmk8nEFZuEf+9Opb30DphYwTPDbgg/OorSAoJOuTpWyDrZaSWQw7FdoevbBRCP2+9z/halXSWcA==",
+      "dependencies": {
+        "bytes": "3.1.1",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.8.1",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.9.6",
+        "raw-body": "2.4.2",
+        "type-is": "~1.6.18"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "server/node_modules/express/node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "server/node_modules/express/node_modules/bytes": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz",
+      "integrity": "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "server/node_modules/express/node_modules/debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "server/node_modules/express/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "server/node_modules/express/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "server/node_modules/express/node_modules/qs": {
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+      "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==",
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "server/node_modules/express/node_modules/raw-body": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.2.tgz",
+      "integrity": "sha512-RPMAFUJP19WIet/99ngh6Iv8fzAbqum4Li7AD6DtGaW2RpMB/11xDoalPiJMTbu6I3hkbMVkATvZrqb9EEqeeQ==",
+      "dependencies": {
+        "bytes": "3.1.1",
+        "http-errors": "1.8.1",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "server/node_modules/express/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "server/node_modules/express/node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
     "server/node_modules/extsprintf": {
       "version": "1.3.0",
       "engines": [
@@ -21293,6 +21543,31 @@
     "server/node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "license": "MIT"
+    },
+    "server/node_modules/finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "server/node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
     },
     "server/node_modules/fn.name": {
       "version": "1.1.0",
@@ -22718,6 +22993,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "server/node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "server/node_modules/raw-body": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
@@ -22918,6 +23201,93 @@
     "server/node_modules/sax": {
       "version": "1.2.1",
       "license": "ISC"
+    },
+    "server/node_modules/send": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.0.0-beta.1.tgz",
+      "integrity": "sha512-OKTRokcl/oo34O8+6aUpj8Jf2Bjw2D0tZzmX0/RvyfVC9ZOZW+HPAWAlhS817IsRaCnzYX1z++h2kHFr2/KNRg==",
+      "dependencies": {
+        "debug": "3.1.0",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.8.1",
+        "mime-types": "~2.1.34",
+        "ms": "2.1.3",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "server/node_modules/send/node_modules/debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "server/node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "server/node_modules/send/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "server/node_modules/send/node_modules/destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg=="
+    },
+    "server/node_modules/send/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "server/node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "server/node_modules/send/node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "server/node_modules/serve-static": {
+      "version": "2.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.0.0-beta.1.tgz",
+      "integrity": "sha512-DEJ9on/tQeFO2Omj7ovT02lCp1YgP4Kb8W2lv2o/4keTFAbgc8HtH3yPd47++2wv9lvQeqiA7FHFDe5+8c4XpA==",
+      "dependencies": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "1.0.0-beta.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "server/node_modules/setprototypeof": {
       "version": "1.1.0",
@@ -26950,6 +27320,7 @@
     },
     "body-parser": {
       "version": "1.20.1",
+      "dev": true,
       "requires": {
         "bytes": "3.1.2",
         "content-type": "~1.0.4",
@@ -26966,10 +27337,12 @@
       },
       "dependencies": {
         "bytes": {
-          "version": "3.1.2"
+          "version": "3.1.2",
+          "dev": true
         },
         "debug": {
           "version": "2.6.9",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -27440,7 +27813,8 @@
       "version": "1.9.0"
     },
     "cookie": {
-      "version": "0.5.0"
+      "version": "0.5.0",
+      "dev": true
     },
     "cookie-parser": {
       "version": "1.4.6",
@@ -28944,6 +29318,7 @@
       "version": "4.18.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
       "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "dev": true,
       "requires": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -28979,25 +29354,30 @@
       },
       "dependencies": {
         "array-flatten": {
-          "version": "1.1.1"
+          "version": "1.1.1",
+          "dev": true
         },
         "content-disposition": {
           "version": "0.5.4",
+          "dev": true,
           "requires": {
             "safe-buffer": "5.2.1"
           }
         },
         "debug": {
           "version": "2.6.9",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
         "path-to-regexp": {
-          "version": "0.1.7"
+          "version": "0.1.7",
+          "dev": true
         },
         "range-parser": {
-          "version": "1.2.1"
+          "version": "1.2.1",
+          "dev": true
         }
       }
     },
@@ -29135,6 +29515,7 @@
     },
     "finalhandler": {
       "version": "1.2.0",
+      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
@@ -29147,6 +29528,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -29767,6 +30149,7 @@
     },
     "http-errors": {
       "version": "2.0.0",
+      "dev": true,
       "requires": {
         "depd": "2.0.0",
         "inherits": "2.0.4",
@@ -31781,7 +32164,7 @@
         "errorhandler": "^1.4.3",
         "eslint": "^8.33.0",
         "eslint-plugin-jest": "^27.2.1",
-        "express": "^4.18.2",
+        "express": "^5.0.0-beta.1",
         "express-session": "^1.17.3",
         "fb": "~1.0.2",
         "http-proxy": "~1.18.1",
@@ -32586,6 +32969,11 @@
           "version": "2.0.1",
           "dev": true
         },
+        "array-flatten": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
+          "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
+        },
         "arrify": {
           "version": "1.0.1"
         },
@@ -32896,9 +33284,29 @@
             "on-headers": "~1.0.1"
           }
         },
+        "content-disposition": {
+          "version": "0.5.4",
+          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+          "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+          "requires": {
+            "safe-buffer": "5.2.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+              "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+            }
+          }
+        },
         "convert-source-map": {
           "version": "2.0.0",
           "dev": true
+        },
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
         },
         "cookiejar": {
           "version": "2.1.4",
@@ -33146,6 +33554,130 @@
           "version": "0.1.2",
           "dev": true
         },
+        "express": {
+          "version": "5.0.0-beta.1",
+          "resolved": "https://registry.npmjs.org/express/-/express-5.0.0-beta.1.tgz",
+          "integrity": "sha512-KPtBrlZoQu2Ps0Ce/Imqtq73AB0KBJ8Gx59yZQ3pmDJU2/LhcoZETo03oSgtTQufbcLXt/WBITk/jMjl/WMyrQ==",
+          "requires": {
+            "accepts": "~1.3.7",
+            "array-flatten": "3.0.0",
+            "body-parser": "2.0.0-beta.1",
+            "content-disposition": "0.5.4",
+            "content-type": "~1.0.4",
+            "cookie": "0.4.1",
+            "cookie-signature": "1.0.6",
+            "debug": "3.1.0",
+            "depd": "~1.1.2",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "finalhandler": "~1.1.2",
+            "fresh": "0.5.2",
+            "merge-descriptors": "1.0.1",
+            "methods": "~1.1.2",
+            "mime-types": "~2.1.34",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.3",
+            "path-is-absolute": "1.0.1",
+            "proxy-addr": "~2.0.7",
+            "qs": "6.9.6",
+            "range-parser": "~1.2.1",
+            "router": "2.0.0-beta.1",
+            "safe-buffer": "5.2.1",
+            "send": "1.0.0-beta.1",
+            "serve-static": "2.0.0-beta.1",
+            "setprototypeof": "1.2.0",
+            "statuses": "~1.5.0",
+            "type-is": "~1.6.18",
+            "utils-merge": "1.0.1",
+            "vary": "~1.1.2"
+          },
+          "dependencies": {
+            "body-parser": {
+              "version": "2.0.0-beta.1",
+              "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.0.0-beta.1.tgz",
+              "integrity": "sha512-I1v2bt2OdYqtmk8nEFZuEf+9Opb30DphYwTPDbgg/OorSAoJOuTpWyDrZaSWQw7FdoevbBRCP2+9z/halXSWcA==",
+              "requires": {
+                "bytes": "3.1.1",
+                "content-type": "~1.0.4",
+                "debug": "2.6.9",
+                "depd": "~1.1.2",
+                "http-errors": "1.8.1",
+                "iconv-lite": "0.4.24",
+                "on-finished": "~2.3.0",
+                "qs": "6.9.6",
+                "raw-body": "2.4.2",
+                "type-is": "~1.6.18"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "2.6.9",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                  "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                }
+              }
+            },
+            "bytes": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz",
+              "integrity": "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg=="
+            },
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "depd": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+              "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="
+            },
+            "http-errors": {
+              "version": "1.8.1",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+              "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+              "requires": {
+                "depd": "~1.1.2",
+                "inherits": "2.0.4",
+                "setprototypeof": "1.2.0",
+                "statuses": ">= 1.5.0 < 2",
+                "toidentifier": "1.0.1"
+              }
+            },
+            "qs": {
+              "version": "6.9.6",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+              "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
+            },
+            "raw-body": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.2.tgz",
+              "integrity": "sha512-RPMAFUJP19WIet/99ngh6Iv8fzAbqum4Li7AD6DtGaW2RpMB/11xDoalPiJMTbu6I3hkbMVkATvZrqb9EEqeeQ==",
+              "requires": {
+                "bytes": "3.1.1",
+                "http-errors": "1.8.1",
+                "iconv-lite": "0.4.24",
+                "unpipe": "1.0.0"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+              "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+            },
+            "setprototypeof": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+              "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+            }
+          }
+        },
         "extsprintf": {
           "version": "1.3.0"
         },
@@ -33180,6 +33712,30 @@
         },
         "file-uri-to-path": {
           "version": "1.0.0"
+        },
+        "finalhandler": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+          "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.3",
+            "statuses": "~1.5.0",
+            "unpipe": "~1.0.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
         },
         "fn.name": {
           "version": "1.1.0"
@@ -34141,6 +34697,11 @@
           "version": "1.1.8",
           "dev": true
         },
+        "range-parser": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+          "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+        },
         "raw-body": {
           "version": "2.5.2",
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
@@ -34285,6 +34846,85 @@
         },
         "sax": {
           "version": "1.2.1"
+        },
+        "send": {
+          "version": "1.0.0-beta.1",
+          "resolved": "https://registry.npmjs.org/send/-/send-1.0.0-beta.1.tgz",
+          "integrity": "sha512-OKTRokcl/oo34O8+6aUpj8Jf2Bjw2D0tZzmX0/RvyfVC9ZOZW+HPAWAlhS817IsRaCnzYX1z++h2kHFr2/KNRg==",
+          "requires": {
+            "debug": "3.1.0",
+            "destroy": "~1.0.4",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "1.8.1",
+            "mime-types": "~2.1.34",
+            "ms": "2.1.3",
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.2.1",
+            "statuses": "~1.5.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "requires": {
+                "ms": "2.0.0"
+              },
+              "dependencies": {
+                "ms": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                  "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+                }
+              }
+            },
+            "depd": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+              "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="
+            },
+            "destroy": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+              "integrity": "sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg=="
+            },
+            "http-errors": {
+              "version": "1.8.1",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+              "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+              "requires": {
+                "depd": "~1.1.2",
+                "inherits": "2.0.4",
+                "setprototypeof": "1.2.0",
+                "statuses": ">= 1.5.0 < 2",
+                "toidentifier": "1.0.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+              "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+            },
+            "setprototypeof": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+              "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+            }
+          }
+        },
+        "serve-static": {
+          "version": "2.0.0-beta.1",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.0.0-beta.1.tgz",
+          "integrity": "sha512-DEJ9on/tQeFO2Omj7ovT02lCp1YgP4Kb8W2lv2o/4keTFAbgc8HtH3yPd47++2wv9lvQeqiA7FHFDe5+8c4XpA==",
+          "requires": {
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "parseurl": "~1.3.3",
+            "send": "1.0.0-beta.1"
+          }
         },
         "setprototypeof": {
           "version": "1.1.0"
@@ -35346,6 +35986,7 @@
     },
     "on-finished": {
       "version": "2.4.1",
+      "dev": true,
       "requires": {
         "ee-first": "1.1.1"
       }
@@ -35500,8 +36141,7 @@
       "dev": true
     },
     "path-is-absolute": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -35922,6 +36562,7 @@
     },
     "raw-body": {
       "version": "2.5.1",
+      "dev": true,
       "requires": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -35930,7 +36571,8 @@
       },
       "dependencies": {
         "bytes": {
-          "version": "3.1.2"
+          "version": "3.1.2",
+          "dev": true
         }
       }
     },
@@ -37259,6 +37901,31 @@
         }
       }
     },
+    "router": {
+      "version": "2.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.0.0-beta.1.tgz",
+      "integrity": "sha512-GLoYgkhAGAiwVda5nt6Qd4+5RAPuQ4WIYLlZ+mxfYICI+22gnIB3eCfmhgV8+uJNPS1/39DOYi/vdrrz0/ouKA==",
+      "requires": {
+        "array-flatten": "3.0.0",
+        "methods": "~1.1.2",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "3.2.0",
+        "setprototypeof": "1.2.0",
+        "utils-merge": "1.0.1"
+      },
+      "dependencies": {
+        "array-flatten": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
+          "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
+        },
+        "path-to-regexp": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.2.0.tgz",
+          "integrity": "sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA=="
+        }
+      }
+    },
     "run-parallel": {
       "version": "1.2.0",
       "dev": true,
@@ -37340,6 +38007,7 @@
     },
     "send": {
       "version": "0.18.0",
+      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -37358,23 +38026,28 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           },
           "dependencies": {
             "ms": {
-              "version": "2.0.0"
+              "version": "2.0.0",
+              "dev": true
             }
           }
         },
         "mime": {
-          "version": "1.6.0"
+          "version": "1.6.0",
+          "dev": true
         },
         "ms": {
-          "version": "2.1.3"
+          "version": "2.1.3",
+          "dev": true
         },
         "range-parser": {
-          "version": "1.2.1"
+          "version": "1.2.1",
+          "dev": true
         }
       }
     },
@@ -37574,6 +38247,7 @@
     },
     "serve-static": {
       "version": "1.15.0",
+      "dev": true,
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
@@ -37767,7 +38441,8 @@
       "dev": true
     },
     "statuses": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "dev": true
     },
     "string_decoder": {
       "version": "0.10.31"

--- a/server/app.ts
+++ b/server/app.ts
@@ -1136,7 +1136,7 @@ const fetchIndexForAdminPage = (
   res: express.Response,
 ) => {
   res.setHeader("Content-Type", "text/html");
-  res.sendfile(__dirname + "/client/index.html");
+  res.sendFile(__dirname + "/client/index.html");
 };
 
 app.get("^/$", fetchIndexForAdminPage);
@@ -1186,7 +1186,7 @@ const fetchEmbed = (req: express.Request, res: express.Response) => {
       encoding: "utf8",
     });
     res.set(JSON.parse(headers));
-    res.sendfile(__dirname + "/embed/embed.js");
+    res.sendFile(__dirname + "/embed/embed.js");
     return;
   }
 
@@ -1210,7 +1210,7 @@ const fetchEmbed = (req: express.Request, res: express.Response) => {
     return;
   }
   // all other files just need headers
-  res.sendfile(__dirname + path);
+  res.sendFile(__dirname + path);
 };
 
 app.get(/^\/embed$/, fetchEmbed);

--- a/server/package.json
+++ b/server/package.json
@@ -32,7 +32,7 @@
     "cookie-parser": "^1.4.6",
     "dotenv": "^16.0.3",
     "errorhandler": "^1.4.3",
-    "express": "^4.18.2",
+    "express": "^5.0.0-beta.1",
     "express-session": "^1.17.3",
     "fb": "~1.0.2",
     "http-proxy": "~1.18.1",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -4444,7 +4444,7 @@ function denyIfNotFromWhitelistedDomain(
     headers?: { referrer: string };
     p: { zid: any; domain_whitelist_override_key: any };
   },
-  res: { send: (arg0: number, arg1: string) => void },
+  res: any,
   next: (arg0?: string) => void,
 ) {
   let isWithinIframe =
@@ -4486,13 +4486,13 @@ function denyIfNotFromWhitelistedDomain(
       if (isOk) {
         next();
       } else {
-        res.send(403, "polis_err_domain");
+        res.status(403).send("polis_err_domain");
         next("polis_err_domain");
       }
     })
     .catch(function (err: any) {
       logger.error("error in isParentDomainWhitelisted", err);
-      res.send(403, "polis_err_domain");
+      res.status(403).send("polis_err_domain");
       next("polis_err_domain_misc");
     });
 }
@@ -7116,7 +7116,7 @@ function handle_PUT_conversations(
 
 async function handle_DELETE_metadata_questions(
   req: { p: { uid?: any; pmqid: any } },
-  res: { send: (arg0: number) => void },
+  res: { sendStatus: (arg0: number) => void },
 ) {
   let uid = req.p.uid;
   let pmqid = req.p.pmqid;
@@ -7160,12 +7160,12 @@ async function handle_DELETE_metadata_questions(
     fail(res, 500, "polis_err_delete_participant_metadata_question", err);
   }
 
-  res.send(200);
+  res.sendStatus(200);
 }
 
 async function handle_DELETE_metadata_answers(
   req: { p: { uid?: any; pmaid: any } },
-  res: { send: (arg0: number) => void },
+  res: { sendStatus: (arg0: number) => void },
 ) {
   let uid = req.p.uid;
   let pmaid = req.p.pmaid;
@@ -7203,7 +7203,7 @@ async function handle_DELETE_metadata_answers(
   } catch (err) {
     return fail(res, 500, "polis_err_delete_participant_metadata_answers", err);
   }
-  res.send(200);
+  res.sendStatus(200);
 }
 
 async function getZidForAnswer(pmaid: any) {
@@ -9330,13 +9330,13 @@ function middleware_log_middleware_errors(
 
 function middleware_check_if_options(
   req: { method: string },
-  res: { send: (arg0: number) => any },
+  res: { sendStatus: (arg0: number) => any },
   next: () => any,
 ) {
   if (req.method.toLowerCase() !== "options") {
     return next();
   }
-  return res.send(204);
+  return res.sendStatus(204);
 }
 
 let middleware_responseTime_start = responseTime(function (


### PR DESCRIPTION
This PR branches off the PR for migrating to express 4: https://github.com/canvasxyz/metropolis/pull/27

The main change here is that `res.sendfile` is replaced with `res.sendFile`, and `res.json` and `res.send` can't be called with the status code (we must use `res.status` or `res.sendStatus` instead).

The big improvement with express 5 is that errors in async handlers/middleware are all handled without having to call `next(...)`.