### PR TITLE
Rjwebb/fix remaining eslint bugs

### DIFF
--- a/client/.eslintrc.yml
+++ b/client/.eslintrc.yml
@@ -18,6 +18,7 @@ rules:
   # snake_case API params and properties makes this a tangled process.
   camelcase: off
   'no-console': off
+  'no-use-before-define': off
 parser: '@typescript-eslint/parser'
 parserOptions:
   ecmaFeatures:

--- a/client/src/actions.tsx
+++ b/client/src/actions.tsx
@@ -3,6 +3,7 @@
 import $ from "jquery"
 import api from "./util/api"
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Action = any
 
 /* ======= Types ======= */

--- a/client/src/globals.d.ts
+++ b/client/src/globals.d.ts
@@ -3,11 +3,6 @@ import { ThemeUIStyleObject } from "theme-ui"
 
 declare module "*.md"
 
-declare namespace FB {
-  const api: any
-  const login: any
-}
-
 declare module "react" {
   interface Attributes {
     sx?: ThemeUIStyleObject

--- a/client/src/pages/account.tsx
+++ b/client/src/pages/account.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import { Box, Heading, Image } from "theme-ui"
-import { TbExternalLink } from "react-icons/tb"
 import { Link as RouterLink } from "react-router-dom"
 
 import Spinner from "../components/spinner"

--- a/client/src/pages/dashboard/conversation.tsx
+++ b/client/src/pages/dashboard/conversation.tsx
@@ -281,7 +281,7 @@ const ReportCommentRow = ({
   reportComment: ReportComment
   maxCount: number
 }) => {
-  const { agree_count, disagree_count, pass_count, count, tid, txt } = reportComment
+  const { agree_count, disagree_count, pass_count, tid, txt } = reportComment
   const row = { display: "flex" }
   const bar = { px: "1px", py: "2px", lineHeight: 1.2 }
   const text = { display: "inline-block", fontSize: "0.88em", position: "relative", left: "4px" }

--- a/client/src/pages/landing/createuser.tsx
+++ b/client/src/pages/landing/createuser.tsx
@@ -3,7 +3,7 @@
 import React from "react"
 import { ConnectedProps, connect } from "react-redux"
 import { doCreateUser } from "../../actions"
-import { Heading, Box, Text, Button, jsx } from "theme-ui"
+import { Heading, Box, Button, jsx } from "theme-ui"
 
 import { Link } from "react-router-dom"
 import strings from "../../intl"

--- a/client/src/pages/survey/survey_cards.tsx
+++ b/client/src/pages/survey/survey_cards.tsx
@@ -8,7 +8,7 @@ import { TbExternalLink } from "react-icons/tb"
 import { surveyBox } from "./index"
 import SurveyCard from "./survey_card"
 
-const PrefilledComment = ({ zid_metadata, text }: { zid_metadata; text: string }) => {
+const PrefilledComment = ({ text }: { zid_metadata; text: string }) => {
   return (
     <Box
       sx={{

--- a/client/src/reducers/comments.ts
+++ b/client/src/reducers/comments.ts
@@ -16,7 +16,7 @@ const accepted_comments = (
         loading: true,
         error: null,
       })
-    case types.RECEIVE_COMMENTS:
+    case types.RECEIVE_COMMENTS: {
       const comments = [...action.data]
       comments.sort((a, b) => a.tid.localeCompare(b.tid))
       return Object.assign({}, state, {
@@ -24,6 +24,7 @@ const accepted_comments = (
         error: null,
         comments,
       })
+    }
     case types.COMMENTS_FETCH_ERROR:
       return Object.assign({}, state, {
         loading: false,

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -11,6 +11,7 @@
   },
   "rules": {
     "@typescript-eslint/no-unused-vars": "off",
+    "@typescript-eslint/no-use-before-define": ["warn", "nofunc"]
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
Some more lint fixes here:
- Use the eslint typescript plugin's "no-use-before-define" implementation rather than the default eslint one, fixes some issues with `import React from "react";` causing lint errors
- Disable the `no-explicit-any` error for `Action`
- Remove the unused `FB` namespace from `client` (the only place we are using this is in `client-embed`?)
- Remove some unused imports and props
- Fix case block formatting on the comments reducer