### PR TITLE
Rjwebb/add sentiment check comments

### DIFF
--- a/client/src/pages/dashboard/conversation.tsx
+++ b/client/src/pages/dashboard/conversation.tsx
@@ -12,6 +12,7 @@ import api from "../../util/api"
 import Survey, { surveyBox } from "../survey"
 import { populateZidMetadataStore } from "../../actions"
 import { SentimentCheck } from "./sentiment_check"
+import { SentimentCheckComments } from "./sentiment_check_comments"
 import { Frontmatter, Collapsible } from "./front_matter"
 import { MIN_SEED_RESPONSES } from "./index"
 
@@ -201,6 +202,11 @@ export const DashboardConversation = ({
                 Sentiment Check
               </Box>
               <SentimentCheck
+                user={user}
+                zid_metadata={zid_metadata}
+                key={zid_metadata.conversation_id}
+              />
+              <SentimentCheckComments
                 user={user}
                 zid_metadata={zid_metadata}
                 key={zid_metadata.conversation_id}

--- a/client/src/pages/dashboard/conversation.tsx
+++ b/client/src/pages/dashboard/conversation.tsx
@@ -208,8 +208,7 @@ export const DashboardConversation = ({
               />
               <SentimentCheckComments
                 user={user}
-                zid_metadata={zid_metadata}
-                key={zid_metadata.conversation_id}
+                conversationId={zid_metadata.conversation_id}
               />
             </Box>
           )}

--- a/client/src/pages/dashboard/sentiment_check_comments.tsx
+++ b/client/src/pages/dashboard/sentiment_check_comments.tsx
@@ -64,29 +64,32 @@ export const SentimentCheckComments: React.FC<{ user; conversationId: string }> 
                 }}
                 key={comment.id}
               >
-                <Flex
-                  sx={{
-                    flexDirection: "row",
-                    alignItems: "center"
-                  }}
-                >
-                  <Link href={`https://github.com/${comment.github_username}`} target="_blank">
-                    <Image
-                      src={`https://github.com/${comment.github_username}.png`}
-                      width="34"
-                      height="34"
-                      style={{
-                        borderRadius: 6,
-                        marginRight: "8px",
-                        background: "#ccc",
-                        marginTop: "2px",
-                      }}
-                    />
-                  </Link>
-                  <Text sx={{flexGrow: 1}}>{comment.github_username} - {new Date(parseInt(comment.created)).toLocaleString()}</Text>
-                  {comment.can_delete && <Text sx={{cursor: "pointer"}} onClick={() => deleteComment(comment.id)}>Delete</Text>}
-                </Flex>
-                <Box>{comment.comment}</Box>
+                {comment.is_deleted ? <Text>[deleted]</Text> :
+                <>
+                  <Flex
+                    sx={{
+                      flexDirection: "row",
+                      alignItems: "center"
+                    }}
+                  >
+                    <Link href={`https://github.com/${comment.github_username}`} target="_blank">
+                      <Image
+                        src={`https://github.com/${comment.github_username}.png`}
+                        width="34"
+                        height="34"
+                        style={{
+                          borderRadius: 6,
+                          marginRight: "8px",
+                          background: "#ccc",
+                          marginTop: "2px",
+                        }}
+                      />
+                    </Link>
+                    <Text sx={{flexGrow: 1}}>{comment.github_username} - {new Date(parseInt(comment.created)).toLocaleString()}</Text>
+                    {comment.can_delete && <Text sx={{cursor: "pointer"}} onClick={() => deleteComment(comment.id)}>Delete</Text>}
+                  </Flex>
+                  <Box>{comment.comment}</Box>
+                </>}
               </Flex>
             ))}
           </Flex>

--- a/client/src/pages/dashboard/sentiment_check_comments.tsx
+++ b/client/src/pages/dashboard/sentiment_check_comments.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from "react"
-import { Box, Text } from "theme-ui";
+import { Box, Flex, Image, Link, Text } from "theme-ui";
 import useSWR from "swr";
+import { formatTimeAgo } from "../../util/misc";
 
 const fetcher = url => fetch(url).then(r => r.json())
 
@@ -32,15 +33,61 @@ export const SentimentCheckComments: React.FC<{ user; conversationId: string }> 
   }, [conversationId, user])
 
   return (
-    <Box>
-      <Text>Comments</Text><br/>
-      {sentimentComments.length > 0 ? <ul>
-        {sentimentComments.map((comment) => (
-          <li key={comment.id}>
-            {comment.comment} by {comment.uid} on {comment.created}
-          </li>
-        ))}
-      </ul> : <>No comments yet</>}
+    <Flex sx={{flexDirection:"column", gap: "8px"}}>
+      <Text
+        sx={{
+          fontWeight: "bold",
+        }}
+      >
+        Comments
+      </Text>
+      {
+        sentimentComments.length > 0 ?
+          <Flex
+            sx={{
+              flexDirection: "column",
+              gap: "8px",
+            }}
+          >
+            {sentimentComments.map((comment) => (
+              <Flex
+                sx={{
+                  flexDirection: "column",
+                  padding: "8px",
+                  gap: "6px"
+                }}
+                key={comment.id}
+              >
+                <Flex
+                  sx={{
+                    flexDirection: "row",
+                    alignItems: "center"
+                  }}
+                >
+                  <Link href={`https://github.com/${comment.github_username}`} target="_blank">
+                    <Image
+                      src={`https://github.com/${comment.github_username}.png`}
+                      width="34"
+                      height="34"
+                      style={{
+                        borderRadius: 6,
+                        marginRight: "8px",
+                        background: "#ccc",
+                        marginTop: "2px",
+                      }}
+                    />
+                  </Link>
+                  <Text>{comment.github_username} - {new Date(parseInt(comment.created)).toLocaleString()}</Text>
+                </Flex>
+                <Box>{comment.comment}</Box>
+              </Flex>
+            ))}
+          </Flex>
+        :
+          <>
+            No comments yet
+          </>
+      }
 
       <input
         type="text"
@@ -49,6 +96,6 @@ export const SentimentCheckComments: React.FC<{ user; conversationId: string }> 
         value={comment}
       />
       <button onClick={() => submitComment(comment)}>Submit</button>
-    </Box>
+    </Flex>
   )
 }

--- a/client/src/pages/dashboard/sentiment_check_comments.tsx
+++ b/client/src/pages/dashboard/sentiment_check_comments.tsx
@@ -1,0 +1,47 @@
+import React, { useCallback, useState } from "react"
+import { Box, Text } from "theme-ui";
+import useSWR from "swr";
+
+const fetcher = url => fetch(url).then(r => r.json())
+
+
+export const SentimentCheckComments: React.FC<{ user; zid_metadata }> = ({
+  user,
+  zid_metadata,
+}) => {
+  const { data } = useSWR(
+    `/api/v3/conversation/sentiment_comments?conversation_id=${zid_metadata.conversation_id}`,
+    fetcher
+  )
+  const [comment, setComment] = useState("")
+
+  const submitComment = useCallback((comment: string) => {
+    fetch(`/api/v3/conversation/sentiment_comments?conversation_id=${zid_metadata.conversation_id}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        comment,
+      }),
+    }).then(() => {
+      setComment("")
+    })
+  }, [zid_metadata])
+
+  return (
+    <Box>
+      <Text>Comments</Text><br/>
+      list comments here<br/>
+
+      submit comment form here <br/>
+      <input
+        type="text"
+        placeholder="Comment"
+        onChange={(e) => setComment(e.target.value)}
+        value={comment}
+      />
+      <button onClick={() => submitComment(comment)}>Submit</button>
+    </Box>
+  )
+}

--- a/client/src/pages/dashboard/sentiment_check_comments.tsx
+++ b/client/src/pages/dashboard/sentiment_check_comments.tsx
@@ -5,18 +5,19 @@ import useSWR from "swr";
 const fetcher = url => fetch(url).then(r => r.json())
 
 
-export const SentimentCheckComments: React.FC<{ user; zid_metadata }> = ({
+export const SentimentCheckComments: React.FC<{ user; conversationId: string }> = ({
   user,
-  zid_metadata,
+  conversationId,
 }) => {
-  const { data } = useSWR(
-    `/api/v3/conversation/sentiment_comments?conversation_id=${zid_metadata.conversation_id}`,
+  const { data, mutate } = useSWR(
+    `/api/v3/conversation/sentiment_comments?conversation_id=${conversationId}`,
     fetcher
   )
+  const sentimentComments = data || []
   const [comment, setComment] = useState("")
 
   const submitComment = useCallback((comment: string) => {
-    fetch(`/api/v3/conversation/sentiment_comments?conversation_id=${zid_metadata.conversation_id}`, {
+    fetch(`/api/v3/conversation/sentiment_comments?conversation_id=${conversationId}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -25,16 +26,22 @@ export const SentimentCheckComments: React.FC<{ user; zid_metadata }> = ({
         comment,
       }),
     }).then(() => {
+      mutate()
       setComment("")
     })
-  }, [zid_metadata])
+  }, [conversationId, user])
 
   return (
     <Box>
       <Text>Comments</Text><br/>
-      list comments here<br/>
+      {sentimentComments.length > 0 ? <ul>
+        {sentimentComments.map((comment) => (
+          <li key={comment.id}>
+            {comment.comment} by {comment.uid} on {comment.created}
+          </li>
+        ))}
+      </ul> : <>No comments yet</>}
 
-      submit comment form here <br/>
       <input
         type="text"
         placeholder="Comment"

--- a/client/src/pages/dashboard/sentiment_check_comments.tsx
+++ b/client/src/pages/dashboard/sentiment_check_comments.tsx
@@ -1,10 +1,8 @@
 import React, { useCallback, useState } from "react"
 import { Box, Flex, Image, Link, Text } from "theme-ui";
 import useSWR from "swr";
-import { formatTimeAgo } from "../../util/misc";
 
 const fetcher = url => fetch(url).then(r => r.json())
-
 
 export const SentimentCheckComments: React.FC<{ user; conversationId: string }> = ({
   user,
@@ -30,7 +28,15 @@ export const SentimentCheckComments: React.FC<{ user; conversationId: string }> 
       mutate()
       setComment("")
     })
-  }, [conversationId, user])
+  }, [conversationId])
+
+  const deleteComment = useCallback((commentId: number) => {
+    fetch(`/api/v3/conversation/sentiment_comments?comment_id=${commentId}`, {
+      method: "DELETE",
+    }).then(() => {
+      mutate()
+    })
+  }, [])
 
   return (
     <Flex sx={{flexDirection:"column", gap: "8px"}}>
@@ -77,7 +83,8 @@ export const SentimentCheckComments: React.FC<{ user; conversationId: string }> 
                       }}
                     />
                   </Link>
-                  <Text>{comment.github_username} - {new Date(parseInt(comment.created)).toLocaleString()}</Text>
+                  <Text sx={{flexGrow: 1}}>{comment.github_username} - {new Date(parseInt(comment.created)).toLocaleString()}</Text>
+                  <Text sx={{cursor: "pointer"}} onClick={() => deleteComment(comment.id)}>Delete</Text>
                 </Flex>
                 <Box>{comment.comment}</Box>
               </Flex>

--- a/client/src/pages/dashboard/sentiment_check_comments.tsx
+++ b/client/src/pages/dashboard/sentiment_check_comments.tsx
@@ -84,7 +84,7 @@ export const SentimentCheckComments: React.FC<{ user; conversationId: string }> 
                     />
                   </Link>
                   <Text sx={{flexGrow: 1}}>{comment.github_username} - {new Date(parseInt(comment.created)).toLocaleString()}</Text>
-                  <Text sx={{cursor: "pointer"}} onClick={() => deleteComment(comment.id)}>Delete</Text>
+                  {comment.can_delete && <Text sx={{cursor: "pointer"}} onClick={() => deleteComment(comment.id)}>Delete</Text>}
                 </Flex>
                 <Box>{comment.comment}</Box>
               </Flex>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16035,6 +16035,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.5.tgz",
+      "integrity": "sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==",
+      "dependencies": {
+        "client-only": "^0.0.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/table": {
       "version": "6.8.1",
       "dev": true,
@@ -18097,6 +18109,7 @@
         "serve-favicon": "^2.5.0",
         "simple-oauth2": "~0.2.1",
         "sql": "~0.34.0",
+        "swr": "^2.2.5",
         "underscore": "~1.12.1",
         "uuid": "^3.1.0",
         "valid-url": "~1.0.9",
@@ -30824,6 +30837,7 @@
         "simple-oauth2": "~0.2.1",
         "sql": "~0.34.0",
         "supertest": "^6.3.3",
+        "swr": "^2.2.5",
         "ts-jest": "^29.0.5",
         "typescript": "~4.3.5",
         "underscore": "~1.12.1",
@@ -36802,6 +36816,15 @@
     },
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0"
+    },
+    "swr": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.5.tgz",
+      "integrity": "sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==",
+      "requires": {
+        "client-only": "^0.0.1",
+        "use-sync-external-store": "^1.2.0"
+      }
     },
     "table": {
       "version": "6.8.1",

--- a/server/app.ts
+++ b/server/app.ts
@@ -159,6 +159,10 @@ import {
   wantCookie,
   wantHeader,
 } from "./src/utils/parameter";
+import {
+  handle_GET_conversation_sentiment_comments,
+  handle_POST_conversation_sentiment_check_comments
+} from "./src/handlers/sentiment_check_comments";
 
 const app = express();
 
@@ -840,6 +844,23 @@ app.put(
   want("subscribe_type", getInt, assignToP),
   handle_PUT_conversations,
 );
+
+app.get(
+  "/api/v3/conversation/sentiment_comments",
+  moveToBody,
+  auth(assignToP),
+  need("conversation_id", getConversationIdFetchZid, assignToPCustom("zid")),
+  handle_GET_conversation_sentiment_comments as any
+)
+
+app.post(
+  "/api/v3/conversation/sentiment_comments",
+  moveToBody,
+  auth(assignToP),
+  need("conversation_id", getConversationIdFetchZid, assignToPCustom("zid")),
+  need("comment", getStringLimitLength(999), assignToP),
+  handle_POST_conversation_sentiment_check_comments as any
+)
 
 app.put(
   "/api/v3/users",

--- a/server/app.ts
+++ b/server/app.ts
@@ -160,6 +160,7 @@ import {
   wantHeader,
 } from "./src/utils/parameter";
 import {
+  handle_DELETE_conversation_sentiment_check_comments,
   handle_GET_conversation_sentiment_comments,
   handle_POST_conversation_sentiment_check_comments
 } from "./src/handlers/sentiment_check_comments";
@@ -860,6 +861,14 @@ app.post(
   need("conversation_id", getConversationIdFetchZid, assignToPCustom("zid")),
   need("comment", getStringLimitLength(999), assignToP),
   handle_POST_conversation_sentiment_check_comments as any
+)
+
+app.delete(
+  "/api/v3/conversation/sentiment_comments",
+  moveToBody,
+  auth(assignToP),
+  need("comment_id", getInt, assignToP),
+  handle_DELETE_conversation_sentiment_check_comments as any
 )
 
 app.put(

--- a/server/app.ts
+++ b/server/app.ts
@@ -849,7 +849,7 @@ app.put(
 app.get(
   "/api/v3/conversation/sentiment_comments",
   moveToBody,
-  auth(assignToP),
+  authOptional(assignToP),
   need("conversation_id", getConversationIdFetchZid, assignToPCustom("zid")),
   handle_GET_conversation_sentiment_comments as any
 )

--- a/server/package.json
+++ b/server/package.json
@@ -58,6 +58,7 @@
     "serve-favicon": "^2.5.0",
     "simple-oauth2": "~0.2.1",
     "sql": "~0.34.0",
+    "swr": "^2.2.5",
     "underscore": "~1.12.1",
     "uuid": "^3.1.0",
     "valid-url": "~1.0.9",

--- a/server/postgres/migrations/000033_add_sentiment_check_comments.sql
+++ b/server/postgres/migrations/000033_add_sentiment_check_comments.sql
@@ -3,7 +3,8 @@ CREATE TABLE sentiment_check_comments(
   zid INTEGER NOT NULL REFERENCES conversations(zid),
   uid INTEGER NOT NULL REFERENCES users(uid),
   created BIGINT DEFAULT now_as_millis(),
-  comment TEXT
+  comment TEXT,
+  is_deleted BOOLEAN DEFAULT FALSE
 );
 
 CREATE INDEX sentiment_check_comments_zid_idx ON sentiment_check_comments USING btree (zid);

--- a/server/postgres/migrations/000033_add_sentiment_check_comments.sql
+++ b/server/postgres/migrations/000033_add_sentiment_check_comments.sql
@@ -1,0 +1,9 @@
+CREATE TABLE sentiment_check_comments(
+  id SERIAL,
+  zid INTEGER NOT NULL REFERENCES conversations(zid),
+  uid INTEGER NOT NULL REFERENCES users(uid),
+  created BIGINT DEFAULT now_as_millis(),
+  comment TEXT
+);
+
+CREATE INDEX sentiment_check_comments_zid_idx ON sentiment_check_comments USING btree (zid);

--- a/server/src/handlers/sentiment_check_comments.ts
+++ b/server/src/handlers/sentiment_check_comments.ts
@@ -1,0 +1,36 @@
+import { Request, Response } from "express";
+import { queryP_readOnly } from "../db/pg-query";
+import fail from "../utils/fail";
+
+
+export async function handle_GET_conversation_sentiment_comments (req: Request, res: Response) {
+  // make sure that this query does not return the zid
+  const query = "SELECT id, comment, uid, created FROM sentiment_check_comments WHERE zid = $1 ORDER BY created ASC;";
+
+  let result;
+  try {
+    result = await queryP_readOnly(query.toString(), [req.p.zid]);
+  } catch (err) {
+    fail(res, 500, "polis_err_get_conversation_sentiment_comments", err);
+    return;
+  }
+
+  res.status(200).json(result);
+}
+
+export async function handle_POST_conversation_sentiment_check_comments (req: Request, res: Response) {
+  const query = "INSERT INTO sentiment_check_comments (zid, uid, comment) VALUES ($1, $2, $3) RETURNING *;";
+
+  let result;
+  try {
+    result = await queryP_readOnly(query.toString(), [req.p.zid, req.p.uid, req.p.comment]);
+  } catch (err) {
+    fail(res, 500, "polis_err_post_conversation_sentiment_check_comments", err);
+    return;
+  }
+
+  res.status(201).json(result);
+}
+
+// export async function handle_PUT_conversation_sentiment_check_comments (req: Request, res: Response) {}
+// export async function handle_DELETE_conversation_sentiment_check_comments (req: Request, res: Response) {}

--- a/server/src/handlers/sentiment_check_comments.ts
+++ b/server/src/handlers/sentiment_check_comments.ts
@@ -49,5 +49,35 @@ export async function handle_POST_conversation_sentiment_check_comments (req: Re
   res.status(201).json(result);
 }
 
-// export async function handle_PUT_conversation_sentiment_check_comments (req: Request, res: Response) {}
-// export async function handle_DELETE_conversation_sentiment_check_comments (req: Request, res: Response) {}
+export async function handle_DELETE_conversation_sentiment_check_comments (req: Request, res: Response) {
+  const selectQuery = "SELECT zid, uid, comment FROM sentiment_check_comments WHERE id = $1;";
+
+  let comments;
+  try {
+    comments = await queryP_readOnly(selectQuery.toString(), [req.p.comment_id]);
+  } catch (err) {
+    fail(res, 500, "polis_err_delete_conversation_sentiment_check_comments", err);
+    return;
+  }
+
+  if(comments.length == 0) {
+    fail(res, 404, "polis_err_delete_conversation_sentiment_check_comments", "sentiment check comment not found");
+    return;
+  }
+  const comment = comments[0]
+
+  if(comment.uid !== req.p.uid) {
+    fail(res, 403, "polis_err_delete_conversation_sentiment_check_comments", "user not authorized to delete this comment");
+    return;
+  }
+
+  const deleteQuery = "DELETE FROM sentiment_check_comments WHERE id = $1;";
+  try {
+    await queryP_readOnly(deleteQuery.toString(), [req.p.comment_id]);
+  } catch (err) {
+    fail(res, 500, "polis_err_delete_conversation_sentiment_check_comments", err);
+    return;
+  }
+
+  res.status(200).json(`comment with id ${req.p.comment_id} deleted`);
+}

--- a/server/src/handlers/sentiment_check_comments.ts
+++ b/server/src/handlers/sentiment_check_comments.ts
@@ -5,7 +5,24 @@ import fail from "../utils/fail";
 
 export async function handle_GET_conversation_sentiment_comments (req: Request, res: Response) {
   // make sure that this query does not return the zid
-  const query = "SELECT id, comment, uid, created FROM sentiment_check_comments WHERE zid = $1 ORDER BY created ASC;";
+  const query = `
+  SELECT
+    scc.comment,
+    scc.created,
+    scc.id,
+    scc.uid,
+    u.github_username
+  FROM
+    sentiment_check_comments as scc
+  JOIN
+    users u
+  ON
+    u.uid = scc.uid
+  WHERE
+    scc.zid = $1
+  ORDER BY
+    scc.created ASC;
+  `;
 
   let result;
   try {


### PR DESCRIPTION
This PR adds a feature that allows users to submit comments under the "sentiment check" section of surveys.

![Screenshot 2024-04-22 at 3 24 21 PM](https://github.com/canvasxyz/metropolis/assets/457206/f60159c0-d891-40c8-9c07-a8e4af00c553)

Changes:
- Created a new `sentiment_check_comments` table to store these comments
- Created a basic unstyled UI for displaying, creating and deleting (only possible if the user is the creator of the comment) sentiment check comments
- Created GET/POST/DELETE API routes to enable this
- Installed [swr](https://swr.vercel.app/) for fetching sentiment comments from the API

Questions for @raykyri:
- Other than the user who posted the comment, do we want anyone else to be able to delete comments? Administrators? The conversation owner?

TODO:
- [ ] Styling
- [ ] API tests - we don't have these for other parts of the app but this would be an easy place to start
- [x] Display "Delete" button based on whether the user can delete comments
- [x] Deleting comments should set an "is_deleted" value, i.e. this is a "soft delete"
- [x] Admins should be able to delete comments as well as the comment creator
- [x] Deleted comments should display a placeholder