### PR TITLE
Rjwebb/add view counts to conversations

### DIFF
--- a/client/src/pages/dashboard/conversation.tsx
+++ b/client/src/pages/dashboard/conversation.tsx
@@ -16,6 +16,7 @@ import { SentimentCheck } from "./sentiment_check"
 import { SentimentCheckComments } from "./sentiment_check_comments"
 import { Frontmatter, Collapsible } from "./front_matter"
 import { MIN_SEED_RESPONSES } from "./index"
+import { incrementViewCount, useViewCount } from "../../reducers/view_counts"
 
 type ReportComment = {
   active: boolean
@@ -118,11 +119,13 @@ export const DashboardConversation = ({
   const [reportComments, setReportComments] = useState<ReportComment[]>([])
   const [maxCount, setMaxCount] = useState<number>(0)
   const [refreshInProgress, setRefreshInProgress] = useState(false)
+  const viewCount = useViewCount(zid_metadata.conversation_id)
 
   useEffect(() => {
     setReport(undefined)
     setReportComments([])
     if (!zid_metadata.conversation_id) return
+    dispatch(incrementViewCount(zid_metadata.conversation_id))
     refreshReport()
   }, [zid_metadata.conversation_id])
 
@@ -212,6 +215,8 @@ export const DashboardConversation = ({
                 })
                 // return `${date.getMonth() + 1}/${date.getUTCDate()}/${date.getFullYear()}`
               })()}
+              <Text> &middot; </Text>
+              {viewCount || "..."} views
               {zid_metadata.github_username === user?.githubUsername && (
                 <Text>
                   <Text> &middot; </Text>

--- a/client/src/reducers/index.ts
+++ b/client/src/reducers/index.ts
@@ -20,12 +20,14 @@ import comments from "./comments"
 import math from "./math"
 import participants from "./participants"
 import conversation_voters from "./voters"
+import view_counts from "./view_counts"
 
 const rootReducer = combineReducers({
   conversations,
   conversations_summary,
   user,
   zid_metadata,
+  view_counts,
   math,
   comments,
   participants,

--- a/client/src/reducers/view_counts.ts
+++ b/client/src/reducers/view_counts.ts
@@ -1,0 +1,56 @@
+// Copyright (C) 2024-present, The Authors. This program is free software: you can redistribute it and/or  modify it under the terms of the GNU Affero General Public License, version 3, as published by the Free Software Foundation. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit"
+import api from "../util/api"
+import { useSelector } from "react-redux"
+import { useAppSelector } from "../hooks"
+
+/* conversation view counts */
+export const incrementViewCountRequest = createAsyncThunk(
+  'view_counts/increment_view_count',
+  async (conversation_id: string) => {
+    const response = await fetch(`/api/v3/increment_conversation_view_count?conversation_id=${conversation_id}`, {
+      method: 'POST',
+    }) as any
+    return {conversation_id, view_count: await response.json()}
+  }
+)
+
+export type ViewCountsState = {
+  seen_conversation_ids: Record<string, boolean>,
+  view_counts: Record<string, number>,
+}
+
+const viewCountsSlice = createSlice({
+  name: "view_counts",
+  initialState: {
+    seen_conversation_ids: {},
+    view_counts: {},
+  } as ViewCountsState,
+  reducers: {
+    setSeenConversationId: (state, action) => {
+      state.seen_conversation_ids[action.payload] = true
+    },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(incrementViewCountRequest.fulfilled, (state, action) => {
+      state.view_counts[action.payload.conversation_id] = action.payload.view_count
+    })
+  }
+})
+
+export const incrementViewCount = (conversation_id) =>
+  (dispatch, getState) => {
+    const state = getState()
+    if (state.view_counts.seen_conversation_ids[conversation_id]) {
+      return
+    }
+    dispatch(viewCountsSlice.actions.setSeenConversationId(conversation_id))
+    dispatch(incrementViewCountRequest(conversation_id))
+}
+
+export const useViewCount = (conversation_id: string) => {
+  return useAppSelector(state => state.view_counts.view_counts[conversation_id] || 0)
+}
+
+export default viewCountsSlice.reducer

--- a/client/src/reducers/view_counts.ts
+++ b/client/src/reducers/view_counts.ts
@@ -1,12 +1,10 @@
 // Copyright (C) 2024-present, The Authors. This program is free software: you can redistribute it and/or  modify it under the terms of the GNU Affero General Public License, version 3, as published by the Free Software Foundation. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit"
-import api from "../util/api"
-import { useSelector } from "react-redux"
 import { useAppSelector } from "../hooks"
 
 /* conversation view counts */
-export const incrementViewCountRequest = createAsyncThunk(
+const incrementViewCountRequest = createAsyncThunk(
   'view_counts/increment_view_count',
   async (conversation_id: string) => {
     const response = await fetch(`/api/v3/increment_conversation_view_count?conversation_id=${conversation_id}`, {
@@ -16,7 +14,7 @@ export const incrementViewCountRequest = createAsyncThunk(
   }
 )
 
-export type ViewCountsState = {
+type ViewCountsState = {
   seen_conversation_ids: Record<string, boolean>,
   view_counts: Record<string, number>,
 }

--- a/server/app.ts
+++ b/server/app.ts
@@ -46,6 +46,7 @@ import {
   handle_GET_conversationsRecentlyStarted,
   handle_GET_conversationStats,
   handle_GET_conversations_summary,
+  handle_GET_conversation_view_count,
   handle_GET_math_correlationMatrix,
   handle_GET_dataExport,
   handle_GET_domainWhitelist,
@@ -1043,6 +1044,14 @@ app.post(
 );
 
 app.get("/api/v3/conversations_summary", handle_GET_conversations_summary);
+
+app.get(
+  "/api/v3/conversation_view_count",
+  authOptional(assignToP),
+  moveToBody,
+  need("conversation_id", getConversationIdFetchZid, assignToPCustom("zid")),
+  handle_GET_conversation_view_count as any,
+);
 
 app.post(
   "/api/v3/query_participants_by_metadata",

--- a/server/app.ts
+++ b/server/app.ts
@@ -46,7 +46,6 @@ import {
   handle_GET_conversationsRecentlyStarted,
   handle_GET_conversationStats,
   handle_GET_conversations_summary,
-  handle_GET_conversation_view_count,
   handle_POST_increment_conversation_view_count,
   handle_GET_math_correlationMatrix,
   handle_GET_dataExport,
@@ -1045,14 +1044,6 @@ app.post(
 );
 
 app.get("/api/v3/conversations_summary", handle_GET_conversations_summary);
-
-app.get(
-  "/api/v3/conversation_view_count",
-  authOptional(assignToP),
-  moveToBody,
-  need("conversation_id", getConversationIdFetchZid, assignToPCustom("zid")),
-  handle_GET_conversation_view_count as any,
-);
 
 app.post(
   "/api/v3/increment_conversation_view_count",

--- a/server/app.ts
+++ b/server/app.ts
@@ -47,6 +47,7 @@ import {
   handle_GET_conversationStats,
   handle_GET_conversations_summary,
   handle_GET_conversation_view_count,
+  handle_POST_increment_conversation_view_count,
   handle_GET_math_correlationMatrix,
   handle_GET_dataExport,
   handle_GET_domainWhitelist,
@@ -1051,6 +1052,14 @@ app.get(
   moveToBody,
   need("conversation_id", getConversationIdFetchZid, assignToPCustom("zid")),
   handle_GET_conversation_view_count as any,
+);
+
+app.post(
+  "/api/v3/increment_conversation_view_count",
+  authOptional(assignToP),
+  moveToBody,
+  need("conversation_id", getConversationIdFetchZid, assignToPCustom("zid")),
+  handle_POST_increment_conversation_view_count as any,
 );
 
 app.post(

--- a/server/postgres/migrations/000036_add_conversation_view_counts_table.sql
+++ b/server/postgres/migrations/000036_add_conversation_view_counts_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE conversation_view_counts (
+  zid INTEGER REFERENCES conversations(zid),
+  view_count INT,
+  PRIMARY KEY (zid)
+);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -7917,6 +7917,21 @@ function createReport(zid: any) {
     ]);
   });
 }
+
+async function handle_GET_conversation_view_count(
+  req: { p: { zid: any } },
+  res: { json: (arg0: any) => void }
+) {
+  let zid = req.p.zid;
+  const result = await queryP("select view_count from conversation_view_counts where zid = ($1)", [zid]);
+
+  if(result.length == 0) {
+    res.json(0);
+  } else {
+    res.json(result[0].view_count);
+  }
+}
+
 function handle_POST_reports(
   req: { p: { zid: any } },
   res: { json: (arg0: any) => void },
@@ -9548,6 +9563,7 @@ export {
   handle_GET_conversationsRecentlyStarted,
   handle_GET_conversationStats,
   handle_GET_conversations_summary,
+  handle_GET_conversation_view_count,
   handle_GET_math_correlationMatrix,
   handle_GET_dataExport,
   handle_GET_domainWhitelist,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -7932,6 +7932,25 @@ async function handle_GET_conversation_view_count(
   }
 }
 
+
+async function handle_POST_increment_conversation_view_count(
+  req: { p: { zid: any } },
+  res: { json: (arg0: any) => void }
+) {
+  let zid = req.p.zid;
+  const result = await queryP(
+    `
+    INSERT INTO conversation_view_counts (zid, view_count)
+    VALUES ($1, 1)
+    ON CONFLICT (zid)
+    DO UPDATE SET view_count = conversation_view_counts.view_count + 1
+    RETURNING view_count;
+    `,
+    [zid]
+  );
+  res.json(result[0].view_count);
+}
+
 function handle_POST_reports(
   req: { p: { zid: any } },
   res: { json: (arg0: any) => void },
@@ -9564,6 +9583,7 @@ export {
   handle_GET_conversationStats,
   handle_GET_conversations_summary,
   handle_GET_conversation_view_count,
+  handle_POST_increment_conversation_view_count,
   handle_GET_math_correlationMatrix,
   handle_GET_dataExport,
   handle_GET_domainWhitelist,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -7918,21 +7918,6 @@ function createReport(zid: any) {
   });
 }
 
-async function handle_GET_conversation_view_count(
-  req: { p: { zid: any } },
-  res: { json: (arg0: any) => void }
-) {
-  let zid = req.p.zid;
-  const result = await queryP("select view_count from conversation_view_counts where zid = ($1)", [zid]);
-
-  if(result.length == 0) {
-    res.json(0);
-  } else {
-    res.json(result[0].view_count);
-  }
-}
-
-
 async function handle_POST_increment_conversation_view_count(
   req: { p: { zid: any } },
   res: { json: (arg0: any) => void }
@@ -9582,7 +9567,6 @@ export {
   handle_GET_conversationsRecentlyStarted,
   handle_GET_conversationStats,
   handle_GET_conversations_summary,
-  handle_GET_conversation_view_count,
   handle_POST_increment_conversation_view_count,
   handle_GET_math_correlationMatrix,
   handle_GET_dataExport,


### PR DESCRIPTION
This PR adds view counts to the conversation view in the dashboard.

When the `DashboardConversation` component is loaded, we send a POST request to the new `/api/v3/increment_conversation_view_count` endpoint, which increments a counter in the new `conversations_view_count` table for a given conversation id and returns the updated counter. This counter is incremented at most once per conversation per page load, so if a user navigates to conversation A, then conversation B, then conversation A, that counts as just one view. The logic that handles this is in the new `view_counts` reducer.

Currently the view count is displayed underneath the proposal title, between the proposal date and the "Edit" link:

![Screenshot 2024-07-09 at 7 23 04 PM](https://github.com/canvasxyz/metropolis/assets/457206/9e46f72b-e289-4659-ad40-fa75eb13f160)
