### PR TITLE
GitHub sync: Request both open and closed PRs when syncing

### DIFF
--- a/server/src/handlers/github_sync.ts
+++ b/server/src/handlers/github_sync.ts
@@ -341,6 +341,7 @@ export async function handle_POST_github_sync(req: Request, res: Response) {
         repo: process.env.FIP_REPO_NAME,
         owner: process.env.FIP_REPO_OWNER,
         per_page: 100,
+        state: "all"
       },
     );
 


### PR DESCRIPTION
Fixes: https://github.com/canvasxyz/metropolis/issues/41

I believe this PR fixes the the issue we found with FIP 92.

Steps to reproduce the bug:
- Create a FIP by opening a PR on the proposals repository
- Sync Metropolis with the repository
- We should see the FIP listed in the Metropolis dashboard
- Close or merge the FIP PR on GitHub
- Sync Metropolis again with the repository
- We should see the FIP listed in the Metropolis dashboard as closed or merged. <- Bug: The FIP was still appearing as "open"

The reason why this was occurring is that in the GitHub sync code, it only queries the GitHub API for *open* PRs in the proposals repository. We should be querying for closed PRs as well. This can be done by setting the `state` field to `all`.