### PR TITLE
WIP: FIP Tracker

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -91,6 +91,7 @@
     "react-popper": "^2.3.0",
     "react-redux": "^8.1.2",
     "react-router-dom": "^5.2.0",
+    "react-router-dom-v5-compat": "^6.26.0",
     "react-textarea-autosize": "^8.5.3",
     "redux": "^5.0.0",
     "redux-thunk": "~2.3.0",

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -36,6 +36,8 @@ import Account from "./pages/account"
 import SurveyWithLoader from "./pages/survey/survey_with_loader"
 import { Placeholder } from "./pages/dashboard/placeholder"
 import { DashboardConversation } from "./pages/dashboard/conversation"
+import { SentimentChecks } from "./pages/dashboard/sentiment_checks"
+import { FipTracker } from "./pages/dashboard/fip_tracker"
 
 /* report */
 import Report from "./pages/report"
@@ -179,6 +181,24 @@ class App extends React.Component<
                 render={() => (
                   <Dashboard user={this.props.user}>
                     <Placeholder />
+                  </Dashboard>
+                )}
+              />
+              <Route
+                exact
+                path="/dashboard/sentiment_checks"
+                render={() => (
+                  <Dashboard user={this.props.user}>
+                    <SentimentChecks />
+                  </Dashboard>
+                )}
+              />
+              <Route
+                exact
+                path="/dashboard/fip_tracker"
+                render={() => (
+                  <Dashboard user={this.props.user}>
+                    <FipTracker />
                   </Dashboard>
                 )}
               />

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -34,6 +34,8 @@ import CreateConversation from "./pages/create_conversation"
 import ConversationAdmin from "./pages/admin"
 import Account from "./pages/account"
 import SurveyWithLoader from "./pages/survey/survey_with_loader"
+import { Placeholder } from "./pages/dashboard/placeholder"
+import { DashboardConversation } from "./pages/dashboard/conversation"
 
 /* report */
 import Report from "./pages/report"
@@ -165,12 +167,20 @@ class App extends React.Component<
               <Route
                 exact
                 path="/"
-                render={() => <Dashboard selectedConversationId={null} user={this.props.user} />}
+                render={() => (
+                  <Dashboard user={this.props.user}>
+                    <Placeholder />
+                  </Dashboard>
+                )}
               />
               <Route
                 exact
                 path="/dashboard"
-                render={() => <Dashboard selectedConversationId={null} user={this.props.user} />}
+                render={() => (
+                  <Dashboard user={this.props.user}>
+                    <Placeholder />
+                  </Dashboard>
+                )}
               />
               <Route
                 path="/dashboard/c/:conversation_id"
@@ -178,7 +188,14 @@ class App extends React.Component<
                   match: {
                     params: { conversation_id },
                   },
-                }) => <Dashboard selectedConversationId={conversation_id} user={this.props.user} />}
+                }) => (
+                  <Dashboard user={this.props.user}>
+                    <DashboardConversation
+                      selectedConversationId={conversation_id}
+                      user={this.props.user}
+                    />
+                  </Dashboard>
+                )}
               />
               <Route exact path="/about" render={() => <Home user={this.props.user} />} />
               <Route exact path="/about2" render={() => <About />} />

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -198,7 +198,7 @@ class App extends React.Component<
                 path="/dashboard/fip_tracker"
                 render={() => (
                   <Dashboard user={this.props.user}>
-                    <FipTracker />
+                    <FipTracker user={this.props.user} />
                   </Dashboard>
                 )}
               />

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -12,6 +12,7 @@ import { ThemeProvider } from "theme-ui"
 import theme from "./theme"
 import App from "./app"
 import { store } from "./store"
+import { CompatRouter } from "react-router-dom-v5-compat"
 
 class Root extends React.Component {
   render() {
@@ -20,11 +21,13 @@ class Root extends React.Component {
         <IconContext.Provider value={{ style: { position: "relative", top: "0.08em" } }}>
           <Provider store={store}>
             <Router>
-              <Route
-                render={(routeProps) => {
-                  return <App {...routeProps} />
-                }}
-              ></Route>
+              <CompatRouter>
+                <Route
+                  render={(routeProps) => {
+                    return <App {...routeProps} />
+                  }}
+                ></Route>
+              </CompatRouter>
             </Router>
           </Provider>
         </IconContext.Provider>

--- a/client/src/pages/dashboard/conversation.tsx
+++ b/client/src/pages/dashboard/conversation.tsx
@@ -15,8 +15,8 @@ import { populateZidMetadataStore } from "../../actions"
 import { SentimentCheck } from "./sentiment_check"
 import { SentimentCheckComments } from "./sentiment_check_comments"
 import { Frontmatter, Collapsible } from "./front_matter"
-import { MIN_SEED_RESPONSES } from "./index"
 import { incrementViewCount, useViewCount } from "../../reducers/view_counts"
+import { MIN_SEED_RESPONSES } from "../../util/misc"
 
 type ReportComment = {
   active: boolean
@@ -109,9 +109,8 @@ export const DashboardConversation = ({
     (state: RootState) => state.zid_metadata,
   )
 
-  const summaryData = useAppSelector(
-    (state: RootState) =>
-      state.conversations_summary.data?.find((c) => c.conversation_id === selectedConversationId),
+  const summaryData = useAppSelector((state: RootState) =>
+    state.conversations_summary.data?.find((c) => c.conversation_id === selectedConversationId),
   )
 
   const [showReport, setShowReport] = useState<boolean>(false)

--- a/client/src/pages/dashboard/conversations_list.tsx
+++ b/client/src/pages/dashboard/conversations_list.tsx
@@ -157,17 +157,11 @@ const ConversationsList = ({
   return (
     <React.Fragment>
       <ListingSelector
-        iconType={TbQuestionMark}
+        to="/dashboard/sentiment_checks"
+        iconType={BiSolidBarChartAlt2}
         label="Sentiment Checks"
-        isSelected={true}
-        onClick={() => {}}
       />
-      <ListingSelector
-        iconType={TbFocus}
-        label="FIP Tracker"
-        isSelected={false}
-        onClick={() => {}}
-      />
+      <ListingSelector to="/dashboard/fip_tracker" iconType={TbFocus} label="FIP Tracker" />
 
       <ListSelector<ConversationListSelection>
         selectedEntryId={selectedConversations}

--- a/client/src/pages/dashboard/conversations_list.tsx
+++ b/client/src/pages/dashboard/conversations_list.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from "react"
+import React, { useState, useEffect } from "react"
 import { useLocalStorage } from "usehooks-ts"
 import { Button, Box, Flex, Text, Link } from "theme-ui"
 import { useHistory, Link as RouterLink } from "react-router-dom"
@@ -14,7 +14,6 @@ import {
   TbHammer,
   TbArchiveOff,
   TbArchive,
-  TbQuestionMark,
   TbFocus,
 } from "react-icons/tb"
 import { BiSolidBarChartAlt2 } from "react-icons/bi"
@@ -87,10 +86,6 @@ const ConversationsList = ({
 
   useEffect(() => {
     dispatch(populateConversationsSummary())
-  }, [])
-
-  const navigateToConversation = useCallback((conversationId) => {
-    hist.push(`/dashboard/c/${conversationId}`)
   }, [])
 
   const nonFIPConversations = conversations.filter(

--- a/client/src/pages/dashboard/conversations_list.tsx
+++ b/client/src/pages/dashboard/conversations_list.tsx
@@ -20,7 +20,7 @@ import {
 import { BiSolidBarChartAlt2 } from "react-icons/bi"
 import { Menu } from "@headlessui/react"
 
-import { formatTimeAgo } from "../../util/misc"
+import { formatTimeAgo, MIN_SEED_RESPONSES } from "../../util/misc"
 import api from "../../util/api"
 import Spinner from "../../components/spinner"
 import { useAppDispatch, useAppSelector } from "../../hooks"
@@ -30,7 +30,6 @@ import {
   ConversationSummary,
   populateConversationsSummary,
 } from "../../reducers/conversations_summary"
-import { MIN_SEED_RESPONSES } from "./index"
 
 import {
   // handleModerateConversation,

--- a/client/src/pages/dashboard/conversations_list.tsx
+++ b/client/src/pages/dashboard/conversations_list.tsx
@@ -6,7 +6,6 @@ import {
   TbExternalLink,
   TbExclamationCircle,
   TbDots,
-  TbDotsVertical,
   TbPencil,
   TbGitMerge,
   TbGitPullRequestClosed,
@@ -37,6 +36,7 @@ import {
   handleCloseConversation,
   handleReopenConversation,
 } from "../../actions"
+import { ListSelector } from "./list_selector"
 
 type ConversationListSelection =
   | "all-fip"
@@ -79,8 +79,10 @@ const ConversationsList = ({
   const { data } = useAppSelector((state: RootState) => state.conversations_summary)
   const conversations = data || []
 
-  const [selectedConversations, setSelectedConversations] =
-    useLocalStorage<ConversationListSelection>("selectedConversations", "all-fip")
+  const [
+    selectedConversations,
+    setSelectedConversations,
+  ] = useLocalStorage<ConversationListSelection>("selectedConversations", "all-fip")
 
   useEffect(() => {
     dispatch(populateConversationsSummary())
@@ -151,176 +153,41 @@ const ConversationsList = ({
     return <React.Fragment></React.Fragment>
   }
 
-  const tab = {
-    mr: "6px",
-    px: "8px",
-    pt: "6px",
-    textAlign: "center",
-    color: "primary",
-    borderRadius: "10px",
-    border: "1px solid lightGray",
-    fontSize: "0.92em",
-    cursor: "pointer",
-    "&:hover": {
-      bg: "bgGrayLight",
-    },
-  }
-
-  const tabSelected = {
-    ...tab,
-    border: "1px solid primary",
-    bg: "primary",
-    color: "#fff",
-    "&:hover": {},
-  }
-
-  const tabCount = {
-    background: "primaryActive",
-    color: "#fff",
-    fontSize: "0.84em",
-    borderRadius: "99px",
-    px: "6px",
-    py: "3px",
-    ml: "2px",
-    top: "-1px",
-    position: "relative",
-  }
-
   return (
     <React.Fragment>
-      <Flex sx={{ pt: "9px", pb: "8px", pl: "13px" }}>
-        <Box
-          sx={selectedConversations === "all-fip" ? tabSelected : tab}
-          onClick={() => setSelectedConversations("all-fip")}
-        >
-          All <Text sx={tabCount}>{openConversations.length + nonFIPConversations.length}</Text>
-        </Box>
-        <Box
-          sx={selectedConversations === "open-fip" ? tabSelected : tab}
-          onClick={() => setSelectedConversations("open-fip")}
-        >
-          FIPs <Text sx={tabCount}>{openConversations.length}</Text>
-        </Box>
-        <Box
-          sx={selectedConversations === "non-fip" ? tabSelected : tab}
-          onClick={() => setSelectedConversations("non-fip")}
-        >
-          Polls <Text sx={tabCount}>{nonFIPConversations.length}</Text>
-        </Box>
-        <Box sx={{ flex: 1 }}></Box>
-        <Box>
-          <Menu>
-            <Menu.Button as="div">
-              <Box sx={{ px: "10px", py: "3px", my: "3px", mr: "5px", cursor: "pointer" }}>
-                <TbDotsVertical />
-              </Box>
-            </Menu.Button>
-            <Menu.Items as={Box}>
-              <Box variant="boxes.menu" sx={{ width: "180px" }}>
-                {/*
-                <Menu.Item>
-                  <Box
-                    variant={
-                      selectedConversations === "all-fip"
-                        ? "boxes.menuitemactive"
-                        : "boxes.menuitem"
-                    }
-                    onClick={() => setSelectedConversations("all-fip")}
-                  >
-                    All
-                  </Box>
-                </Menu.Item>
-                <Menu.Item>
-                  <Box
-                    variant={
-                      selectedConversations === "open-fip"
-                        ? "boxes.menuitemactive"
-                        : "boxes.menuitem"
-                    }
-                    onClick={() => setSelectedConversations("open-fip")}
-                  >
-                    <Flex>
-                      <Box sx={{ flex: 1 }}>FIPs</Box>
-                      <Box sx={{ pr: [1], opacity: 0.6, fontSize: "0.93em", top: "1px" }}>
-                        {openConversations.length}
-                      </Box>
-                    </Flex>
-                  </Box>
-                </Menu.Item>
-                <Menu.Item>
-                  <Box
-                    variant={
-                      selectedConversations === "non-fip"
-                        ? "boxes.menuitemactive"
-                        : "boxes.menuitem"
-                    }
-                    onClick={() => setSelectedConversations("non-fip")}
-                  >
-                    <Flex>
-                      <Box sx={{ flex: 1 }}>Polls</Box>
-                      <Box sx={{ pr: [1], opacity: 0.6, fontSize: "0.93em", top: "1px" }}>
-                        {nonFIPConversations.length}
-                      </Box>
-                    </Flex>
-                  </Box>
-                </Menu.Item>
-                 */}
-                <Menu.Item>
-                  <Box
-                    variant={
-                      selectedConversations === "empty-fip"
-                        ? "boxes.menuitemactive"
-                        : "boxes.menuitem"
-                    }
-                    onClick={() => setSelectedConversations("empty-fip")}
-                  >
-                    <Flex>
-                      <Box sx={{ flex: 1 }}> FIPs (edits)</Box>
-                      <Box sx={{ pr: [1], opacity: 0.6, fontSize: "0.93em", top: "1px" }}>
-                        {emptyFIPConversations.length}
-                      </Box>
-                    </Flex>
-                  </Box>
-                </Menu.Item>
-                <Menu.Item>
-                  <Box
-                    variant={
-                      selectedConversations === "archived"
-                        ? "boxes.menuitemactive"
-                        : "boxes.menuitem"
-                    }
-                    onClick={() => setSelectedConversations("archived")}
-                  >
-                    <Flex>
-                      <Box sx={{ flex: 1 }}> Closed</Box>
-                      <Box sx={{ pr: [1], opacity: 0.6, fontSize: "0.93em", top: "1px" }}>
-                        {archivedConversations.length}
-                      </Box>
-                    </Flex>
-                  </Box>
-                </Menu.Item>
-                {/*
-                <Menu.Item>
-                  <Box
-                    variant={
-                      selectedConversations === "hidden" ? "boxes.menuitemactive" : "boxes.menuitem"
-                    }
-                    onClick={() => setSelectedConversations("hidden")}
-                  >
-                    <Flex>
-                      <Box sx={{ flex: 1 }}> Spam</Box>
-                      <Box sx={{ pr: [1], opacity: 0.6, fontSize: "0.93em", top: "1px" }}>
-                        {hiddenConversations.length}
-                      </Box>
-                    </Flex>
-                  </Box>
-                </Menu.Item>
-                 */}
-              </Box>
-            </Menu.Items>
-          </Menu>
-        </Box>
-      </Flex>
+      <ListSelector<ConversationListSelection>
+        selectedEntryId={selectedConversations}
+        setSelectedEntryId={setSelectedConversations}
+        visibleEntries={[
+          {
+            id: "all-fip",
+            label: "All",
+            count: allConversations.length,
+          },
+          {
+            id: "open-fip",
+            label: "FIPs",
+            count: openConversations.length,
+          },
+          {
+            id: "non-fip",
+            label: "Polls",
+            count: nonFIPConversations.length,
+          },
+        ]}
+        dropdownEntries={[
+          {
+            id: "empty-fip",
+            label: "FIPs (edits)",
+            count: emptyFIPConversations.length,
+          },
+          {
+            id: "archived",
+            label: "Closed",
+            count: archivedConversations.length,
+          },
+        ]}
+      />
       <Box sx={{ height: "calc(100vh - 150px)", overflow: "scroll", pb: "100px" }}>
         {selectedConversations === "empty-fip" && (
           <Box

--- a/client/src/pages/dashboard/conversations_list.tsx
+++ b/client/src/pages/dashboard/conversations_list.tsx
@@ -39,6 +39,7 @@ import {
 } from "../../actions"
 import { ListSelector } from "./list_selector"
 import { ListingSelector } from "./listing_selector"
+import { NavLink } from "react-router-dom-v5-compat"
 
 type ConversationListSelection =
   | "all-fip"
@@ -55,13 +56,11 @@ const ViewCount = ({ initialViewCount, conversation }) => {
 
 const ConversationsList = ({
   user,
-  selectedConversationId,
   setCreateConversationModalIsOpen,
   syncPRs,
   syncInProgress,
 }: {
   user
-  selectedConversationId: string | null
   setCreateConversationModalIsOpen: (arg0: boolean) => void
   syncPRs: () => void
   syncInProgress: boolean
@@ -223,8 +222,6 @@ const ConversationsList = ({
             hist={hist}
             user={user}
             conversation={conversation}
-            selectedConversationId={selectedConversationId}
-            navigateToConversation={navigateToConversation}
             key={conversation.conversation_id}
             initialViewCount={conversation.view_count}
             dispatch={dispatch}
@@ -320,8 +317,6 @@ type ConversationListItemProps = {
   user
   conversation: ConversationSummary
   initialViewCount: number
-  selectedConversationId: string | null
-  navigateToConversation: (conversationId: string) => void
   dispatch
 }
 
@@ -354,8 +349,6 @@ const ConversationListItem = ({
   user,
   conversation,
   initialViewCount,
-  selectedConversationId,
-  navigateToConversation,
   dispatch,
 }: ConversationListItemProps) => {
   const date = new Date(conversation.fip_created || +conversation.created)
@@ -371,128 +364,132 @@ const ConversationListItem = ({
   if (shouldHideDiscussion && conversation.owner !== user?.uid) return
 
   return (
-    <Box
-      sx={{
-        position: "relative",
-        opacity: emptyFIP ? 0.7 : null,
-        pointerEvents: emptyFIP ? "none" : null,
-        padding: "12px 16px",
-        cursor: "pointer",
-        userSelect: "none",
-        fontSize: "15px",
-        lineHeight: 1.2,
-        bg: conversation.conversation_id === selectedConversationId ? "bgGray" : "inherit",
-        "&:hover": {
-          bg: conversation.conversation_id === selectedConversationId ? "bgGray" : "bgGrayLight",
-        },
-      }}
-      onClick={(e) => {
-        e.preventDefault()
-        navigateToConversation(conversation.conversation_id)
-      }}
-      key={conversation.conversation_id}
-    >
-      {shouldHideDiscussion && (
-        <Box sx={{ fontSize: "0.8em", color: "#eb4b4c", ml: "1px", mb: "2px" }}>
-          <TbExclamationCircle color="#eb4b4c" />
-          &nbsp; Needs Example Responses
-        </Box>
-      )}
-      <Flex>
-        <Box sx={{ color: "#84817D", fontSize: "90%", pr: "6px" }}>
-          {getIconForConversation(conversation)}
-        </Box>
-        <Box sx={{ fontWeight: 500, flex: 1 }}>
-          {conversation.fip_title || conversation.github_pr_title || conversation.topic || (
-            <Text sx={{ color: "#84817D" }}>Untitled</Text>
-          )}
-          <Flex sx={{ opacity: 0.6, fontSize: "0.8em", mt: "3px", fontWeight: 400 }}>
-            <Text sx={{ flex: 1 }}>
-              Created {timeAgo} ago &middot;{" "}
-              <ViewCount initialViewCount={initialViewCount} conversation={conversation} /> views
-            </Text>
-          </Flex>
-        </Box>
-      </Flex>
-      {user && (user.uid === conversation.owner || user.isRepoCollaborator || user.isAdmin) && (
+    <NavLink to={`/dashboard/c/${conversation.conversation_id}`}>
+      {({ isActive }) => (
         <Box
-          sx={{ position: "absolute", top: "13px", right: "15px" }}
-          onClick={(e) => e.stopPropagation()}
+          sx={{
+            position: "relative",
+            opacity: emptyFIP ? 0.7 : null,
+            pointerEvents: emptyFIP ? "none" : null,
+            padding: "12px 16px",
+            cursor: "pointer",
+            userSelect: "none",
+            fontSize: "15px",
+            lineHeight: 1.2,
+            color: "black",
+            bg: isActive ? "bgGray" : "inherit",
+            "&:hover": {
+              bg: isActive ? "bgGray" : "bgGrayLight",
+            },
+          }}
+          key={conversation.conversation_id}
         >
-          <Menu>
-            <Menu.Button as="div">
-              <TbDots />
-            </Menu.Button>
-            <Menu.Items as={Box}>
-              <Box variant="boxes.menu" sx={{ width: "190px" }}>
-                <Menu.Item>
-                  <Box
-                    variant="boxes.menuitem"
-                    onClick={() => hist.push(`/m/${conversation.conversation_id}`)}
-                  >
-                    <TbPencil /> Edit
-                  </Box>
-                </Menu.Item>
+          {shouldHideDiscussion && (
+            <Box sx={{ fontSize: "0.8em", color: "#eb4b4c", ml: "1px", mb: "2px" }}>
+              <TbExclamationCircle color="#eb4b4c" />
+              &nbsp; Needs Example Responses
+            </Box>
+          )}
+          <Flex>
+            <Box sx={{ color: "#84817D", fontSize: "90%", pr: "6px" }}>
+              {getIconForConversation(conversation)}
+            </Box>
+            <Box sx={{ fontWeight: 500, flex: 1 }}>
+              {conversation.fip_title || conversation.github_pr_title || conversation.topic || (
+                <Text sx={{ color: "#84817D" }}>Untitled</Text>
+              )}
+              <Flex sx={{ opacity: 0.6, fontSize: "0.8em", mt: "3px", fontWeight: 400 }}>
+                <Text sx={{ flex: 1 }}>
+                  Created {timeAgo} ago &middot;{" "}
+                  <ViewCount initialViewCount={initialViewCount} conversation={conversation} />{" "}
+                  views
+                </Text>
+              </Flex>
+            </Box>
+          </Flex>
+          {user && (user.uid === conversation.owner || user.isRepoCollaborator || user.isAdmin) && (
+            <Box
+              sx={{ position: "absolute", top: "13px", right: "15px" }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Menu>
+                <Menu.Button as="div">
+                  <TbDots />
+                </Menu.Button>
+                <Menu.Items as={Box}>
+                  <Box variant="boxes.menu" sx={{ width: "190px" }}>
+                    <Menu.Item>
+                      <Box
+                        variant="boxes.menuitem"
+                        onClick={() => hist.push(`/m/${conversation.conversation_id}`)}
+                      >
+                        <TbPencil /> Edit
+                      </Box>
+                    </Menu.Item>
 
-                <Menu.Item>
-                  <Box
-                    variant="boxes.menuitem"
-                    onClick={() => hist.push(`/m/${conversation.conversation_id}/comments`)}
-                  >
-                    <TbHammer /> Moderate comments
-                  </Box>
-                </Menu.Item>
-                {user &&
-                  (user.uid === conversation.owner || user.isRepoCollaborator || user.isAdmin) && (
                     <Menu.Item>
                       <Box
                         variant="boxes.menuitem"
-                        onClick={() => {
-                          if (conversation.is_archived) {
-                            if (!confirm("Reopen this discussion?")) return
-                            dispatch(handleReopenConversation(conversation.conversation_id))
-                            location.reload()
-                          } else {
-                            if (!confirm("Close this discussion?")) return
-                            dispatch(handleCloseConversation(conversation.conversation_id))
-                            location.reload()
-                          }
-                        }}
+                        onClick={() => hist.push(`/m/${conversation.conversation_id}/comments`)}
                       >
-                        {conversation.is_archived ? <TbArchiveOff /> : <TbArchive />}{" "}
-                        {conversation.is_archived ? "Reopen" : "Close"}
+                        <TbHammer /> Moderate comments
                       </Box>
                     </Menu.Item>
-                  )}
-                {/* user.githubRepoCollaborator && (
-                  <Box sx={{ mt: "3px", pt: "3px", borderTop: "1px solid #e2ddd5" }}>
-                    <Menu.Item>
-                      <Box
-                        variant="boxes.menuitem"
-                        onClick={() => {
-                          if (conversation.is_hidden) {
-                            if (!confirm("Show this proposal to users again?")) return
-                            dispatch(handleUnmoderateConversation(conversation.conversation_id))
-                            toast.success("Removed from spam")
-                          } else {
-                            if (!confirm("Mark as spam? This will hide the proposal from users."))
-                              return
-                            dispatch(handleModerateConversation(conversation.conversation_id))
-                            toast.success("Moved to spam")
-                          }
-                        }}
-                      >
-                        <TbFlame /> {conversation.is_hidden ? "Unmark spam" : "Mark as spam"}
-                      </Box>
-                    </Menu.Item>
+                    {user &&
+                      (user.uid === conversation.owner ||
+                        user.isRepoCollaborator ||
+                        user.isAdmin) && (
+                        <Menu.Item>
+                          <Box
+                            variant="boxes.menuitem"
+                            onClick={() => {
+                              if (conversation.is_archived) {
+                                if (!confirm("Reopen this discussion?")) return
+                                dispatch(handleReopenConversation(conversation.conversation_id))
+                                location.reload()
+                              } else {
+                                if (!confirm("Close this discussion?")) return
+                                dispatch(handleCloseConversation(conversation.conversation_id))
+                                location.reload()
+                              }
+                            }}
+                          >
+                            {conversation.is_archived ? <TbArchiveOff /> : <TbArchive />}{" "}
+                            {conversation.is_archived ? "Reopen" : "Close"}
+                          </Box>
+                        </Menu.Item>
+                      )}
+                    {/* user.githubRepoCollaborator && (
+                <Box sx={{ mt: "3px", pt: "3px", borderTop: "1px solid #e2ddd5" }}>
+                  <Menu.Item>
+                    <Box
+                      variant="boxes.menuitem"
+                      onClick={() => {
+                        if (conversation.is_hidden) {
+                          if (!confirm("Show this proposal to users again?")) return
+                          dispatch(handleUnmoderateConversation(conversation.conversation_id))
+                          toast.success("Removed from spam")
+                        } else {
+                          if (!confirm("Mark as spam? This will hide the proposal from users."))
+                            return
+                          dispatch(handleModerateConversation(conversation.conversation_id))
+                          toast.success("Moved to spam")
+                        }
+                      }}
+                    >
+                      <TbFlame /> {conversation.is_hidden ? "Unmark spam" : "Mark as spam"}
+                    </Box>
+                  </Menu.Item>
+                </Box>
+              ) */}
                   </Box>
-                ) */}
-              </Box>
-            </Menu.Items>
-          </Menu>
+                </Menu.Items>
+              </Menu>
+            </Box>
+          )}
         </Box>
       )}
-    </Box>
+    </NavLink>
   )
 }
 

--- a/client/src/pages/dashboard/conversations_list.tsx
+++ b/client/src/pages/dashboard/conversations_list.tsx
@@ -14,6 +14,8 @@ import {
   TbHammer,
   TbArchiveOff,
   TbArchive,
+  TbQuestionMark,
+  TbFocus,
 } from "react-icons/tb"
 import { BiSolidBarChartAlt2 } from "react-icons/bi"
 import { Menu } from "@headlessui/react"
@@ -37,6 +39,7 @@ import {
   handleReopenConversation,
 } from "../../actions"
 import { ListSelector } from "./list_selector"
+import { ListingSelector } from "./listing_selector"
 
 type ConversationListSelection =
   | "all-fip"
@@ -155,6 +158,19 @@ const ConversationsList = ({
 
   return (
     <React.Fragment>
+      <ListingSelector
+        iconType={TbQuestionMark}
+        label="Sentiment Checks"
+        isSelected={true}
+        onClick={() => {}}
+      />
+      <ListingSelector
+        iconType={TbFocus}
+        label="FIP Tracker"
+        isSelected={false}
+        onClick={() => {}}
+      />
+
       <ListSelector<ConversationListSelection>
         selectedEntryId={selectedConversations}
         setSelectedEntryId={setSelectedConversations}

--- a/client/src/pages/dashboard/fip_tracker.tsx
+++ b/client/src/pages/dashboard/fip_tracker.tsx
@@ -1,10 +1,140 @@
-import React from "react"
+import React, { useState } from "react"
 import { BiFilter } from "react-icons/bi"
-import { TbAdjustmentsHorizontal, TbSearch } from "react-icons/tb"
+import {
+  TbAdjustmentsHorizontal,
+  TbArrowUpRight,
+  TbCalendar,
+  TbCaretDown,
+  TbCaretRight,
+  TbSearch,
+} from "react-icons/tb"
 
-import { Box, Button, Flex, Input, Text } from "theme-ui"
+import { Box, Button, Flex, Grid, Input, Text } from "theme-ui"
+import { useAppSelector } from "../../hooks"
+import { RootState } from "../../store"
+import { ConversationSummary } from "../../reducers/conversations_summary"
+import { Link } from "react-router-dom-v5-compat"
+
+const Lozenge = ({
+  text,
+  color,
+  bg,
+  borderColor,
+}: {
+  text: string
+  color: string
+  bg: string
+  borderColor: string
+}) => {
+  return (
+    <Box sx={{ bg, borderStyle: "solid", borderColor, borderRadius: "16px", p: [1], color }}>
+      {text}
+    </Box>
+  )
+}
+
+const colorOptions = {
+  "last call": {
+    bg: "#FFF1D9",
+    borderColor: "#FFE4B7",
+    color: "#BD8520",
+  },
+  draft: {
+    bg: "#D5EFFF",
+    borderColor: "#B0D6FF",
+    color: "#006BCA",
+  },
+  accepted: {
+    bg: "#D9F7D1",
+    borderColor: "#BCE7A7",
+    color: "#007A3D",
+  },
+  final: {
+    bg: "#F9D9D9",
+    borderColor: "#F0B0B0",
+    color: "#C30000",
+  },
+}
+
+const FipEntry = ({ conversation }: { conversation: ConversationSummary }) => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const fipStatusKey = conversation.fip_status ? conversation.fip_status.toLowerCase() : "draft"
+  const colors = colorOptions[fipStatusKey] || colorOptions.draft
+
+  return (
+    <Flex
+      key={conversation.conversation_id}
+      sx={{
+        bg: "white",
+        padding: [3],
+        borderStyle: "solid",
+        borderRadius: "8px",
+        borderColor: colors.borderColor,
+        width: "100%",
+        flexDirection: "row",
+        gap: [3],
+        cursor: "pointer",
+      }}
+      onClick={() => setIsOpen(!isOpen)}
+    >
+      <Grid
+        sx={{
+          gridTemplateColumns: "20px 1fr",
+          gridRow: "auto auto",
+          gridColumnGap: "20px",
+          gridRowGap: "20px",
+          width: "100%",
+        }}
+      >
+        <Flex sx={{ flexDirection: "row", gap: [4], alignItems: "center" }}>
+          {isOpen ? <TbCaretDown /> : <TbCaretRight />}
+        </Flex>
+        <Flex sx={{ flexDirection: "row", gap: [4], alignItems: "center" }}>
+          <Text>{conversation.fip_number}</Text>
+          <Text>{conversation.topic}</Text>
+          <Box sx={{ flexGrow: "1" }}></Box>
+          <Lozenge
+            bg={colors.bg}
+            borderColor={colors.borderColor}
+            color={colors.color}
+            text={conversation.fip_status}
+          />
+          <Link
+            to={conversation.github_pr_url}
+            target="_blank"
+            noreferrer="noreferrer"
+            noopener="noopener"
+            sx={{
+              display: "block",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              width: "calc(100% - 20px)",
+            }}
+          >
+            GitHub <TbArrowUpRight />
+          </Link>
+        </Flex>
+        <Box></Box>
+        <Flex sx={{ flexDirection: "row", gap: [2], alignItems: "center" }}>
+          <Lozenge bg="white" borderColor="#ECECEF" color="#4E525B" text="Technical" />
+          <Lozenge bg="white" borderColor="#ECECEF" color="#4E525B" text="Core" /> |
+          <TbCalendar style={{ top: "0px" }} />
+          {new Date(conversation.created).toLocaleDateString()} | 1 author
+          <Box sx={{ flexGrow: "1" }}></Box>
+        </Flex>
+      </Grid>
+    </Flex>
+  )
+}
 
 export const FipTracker = () => {
+  const { data } = useAppSelector((state: RootState) => state.conversations_summary)
+  const conversations = data || []
+
+  const fips = conversations.filter((conversation) => conversation.fip_created !== null)
+
   return (
     <Flex
       sx={{
@@ -93,6 +223,11 @@ export const FipTracker = () => {
           <TbAdjustmentsHorizontal style={{ color: "#B6B8C4", top: "-1px" }} />
           <Text sx={{ color: "#4E525B" }}>Display</Text>
         </Button>
+      </Flex>
+      <Flex sx={{ flexDirection: "column", gap: [3] }}>
+        {fips.map((conversation) => (
+          <FipEntry conversation={conversation} />
+        ))}
       </Flex>
     </Flex>
   )

--- a/client/src/pages/dashboard/fip_tracker.tsx
+++ b/client/src/pages/dashboard/fip_tracker.tsx
@@ -14,6 +14,7 @@ import { useAppSelector } from "../../hooks"
 import { RootState } from "../../store"
 import { ConversationSummary } from "../../reducers/conversations_summary"
 import { Link } from "react-router-dom-v5-compat"
+import { MIN_SEED_RESPONSES } from "../../util/misc"
 
 const Lozenge = ({
   text,
@@ -92,7 +93,11 @@ const FipEntry = ({ conversation }: { conversation: ConversationSummary }) => {
         </Flex>
         <Flex sx={{ flexDirection: "row", gap: [4], alignItems: "center" }}>
           <Text>{conversation.fip_number}</Text>
-          <Text>{conversation.topic}</Text>
+          <Text>
+            {conversation.fip_title || conversation.github_pr_title || conversation.topic || (
+              <Text sx={{ color: "#84817D" }}>Untitled</Text>
+            )}
+          </Text>
           <Box sx={{ flexGrow: "1" }}></Box>
           <Lozenge
             bg={colors.bg}
@@ -129,11 +134,21 @@ const FipEntry = ({ conversation }: { conversation: ConversationSummary }) => {
   )
 }
 
-export const FipTracker = () => {
+export const FipTracker = ({ user }: { user: any }) => {
   const { data } = useAppSelector((state: RootState) => state.conversations_summary)
   const conversations = data || []
 
-  const fips = conversations.filter((conversation) => conversation.fip_created !== null)
+  const fips = conversations.filter((conversation) => {
+    if (!conversation.fip_created) return false
+
+    const shouldHideDiscussion =
+      !conversation.fip_title &&
+      !conversation.github_pr_title &&
+      conversation.comment_count < MIN_SEED_RESPONSES
+
+    if (shouldHideDiscussion && conversation.owner !== user?.uid) return false
+    return true
+  })
 
   return (
     <Flex

--- a/client/src/pages/dashboard/fip_tracker.tsx
+++ b/client/src/pages/dashboard/fip_tracker.tsx
@@ -1,0 +1,11 @@
+import React from "react"
+
+import { Box } from "theme-ui"
+
+export const FipTracker = () => {
+  return (
+    <Box sx={{ maxWidth: [null, "540px"], px: [3], py: [3], pt: [8], margin: "0 auto" }}>
+      <Box>FIP Tracker</Box>
+    </Box>
+  )
+}

--- a/client/src/pages/dashboard/fip_tracker.tsx
+++ b/client/src/pages/dashboard/fip_tracker.tsx
@@ -74,8 +74,8 @@ export const FipTracker = () => {
             gap: [1],
           }}
         >
-          <BiFilter />
-          <Text>Filters</Text>
+          <BiFilter size="1.1em" style={{ color: "#B6B8C4", top: "-1px" }} />
+          <Text sx={{ color: "#4E525B" }}>Filters</Text>
         </Button>
         <Button
           sx={{
@@ -90,8 +90,8 @@ export const FipTracker = () => {
             gap: [1],
           }}
         >
-          <TbAdjustmentsHorizontal />
-          <Text>Display</Text>
+          <TbAdjustmentsHorizontal style={{ color: "#B6B8C4", top: "-1px" }} />
+          <Text sx={{ color: "#4E525B" }}>Display</Text>
         </Button>
       </Flex>
     </Flex>

--- a/client/src/pages/dashboard/fip_tracker.tsx
+++ b/client/src/pages/dashboard/fip_tracker.tsx
@@ -1,11 +1,99 @@
 import React from "react"
+import { BiFilter } from "react-icons/bi"
+import { TbAdjustmentsHorizontal, TbSearch } from "react-icons/tb"
 
-import { Box } from "theme-ui"
+import { Box, Button, Flex, Input, Text } from "theme-ui"
 
 export const FipTracker = () => {
   return (
-    <Box sx={{ maxWidth: [null, "540px"], px: [3], py: [3], pt: [8], margin: "0 auto" }}>
-      <Box>FIP Tracker</Box>
-    </Box>
+    <Flex
+      sx={{
+        px: [3],
+        py: [3],
+        pt: [4],
+        flexDirection: "column",
+        gap: [3],
+      }}
+    >
+      <Text sx={{ fontWeight: 600, fontSize: [2] }}>FIP Tracker</Text>
+      <Flex sx={{ gap: [2], width: "100%" }}>
+        <Box
+          sx={{
+            bg: "white",
+            borderColor: "#E6E6EB",
+            borderStyle: "solid",
+            borderRadius: "8px",
+            borderWidth: "1px",
+            display: "flex",
+            position: "relative",
+          }}
+        >
+          <Box
+            sx={{
+              position: "absolute",
+              height: "100%",
+              display: "flex",
+              flexDirection: "row",
+              alignItems: "center",
+              pointerEvents: "none",
+            }}
+          >
+            <TbSearch
+              size="1.5em"
+              style={{
+                top: "0px",
+                left: "5px",
+                pointerEvents: "none",
+                color: "#B4B6C2",
+              }}
+            />
+          </Box>
+          <Input
+            sx={{
+              margin: "0",
+              paddingLeft: "32px",
+              bg: "unset",
+              color: "#595E66",
+              borderStyle: "none",
+              width: "400px",
+            }}
+            placeholder="Search"
+          />
+        </Box>
+        <Box sx={{ flexGrow: "1" }}></Box>
+        <Button
+          sx={{
+            bg: "white",
+            color: "#51555E",
+            borderColor: "#E6E6EB",
+            minWidth: "unset",
+            ":hover": { bg: "bgOffWhite" },
+            display: "flex",
+            flexDirection: "row",
+            alignItems: "center",
+            gap: [1],
+          }}
+        >
+          <BiFilter />
+          <Text>Filters</Text>
+        </Button>
+        <Button
+          sx={{
+            bg: "white",
+            color: "#51555E",
+            borderColor: "#E6E6EB",
+            minWidth: "unset",
+            ":hover": { bg: "bgOffWhite" },
+            display: "flex",
+            flexDirection: "row",
+            alignItems: "center",
+            gap: [1],
+          }}
+        >
+          <TbAdjustmentsHorizontal />
+          <Text>Display</Text>
+        </Button>
+      </Flex>
+    </Flex>
   )
 }

--- a/client/src/pages/dashboard/index.tsx
+++ b/client/src/pages/dashboard/index.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 
-import React, { useEffect, useState } from "react"
+import React, { PropsWithChildren, useEffect, useState } from "react"
 import { Link as RouterLink, useLocation } from "react-router-dom"
 import { Box, Flex, Text, jsx } from "theme-ui"
 import { toast } from "react-hot-toast"
@@ -8,11 +8,8 @@ import { toast } from "react-hot-toast"
 import api from "../../util/api"
 import { User } from "../../util/types"
 import { CreateConversationModal } from "../CreateConversationModal"
-import { DashboardConversation } from "./conversation"
 import { DashboardUserButton } from "./user_button"
 import ConversationsList from "./conversations_list"
-
-import { Placeholder } from "./placeholder"
 
 const LogoBlock = () => {
   return (
@@ -44,10 +41,9 @@ const LogoBlock = () => {
 
 type DashboardProps = {
   user: User
-  selectedConversationId: string | null
 }
 
-const Dashboard = ({ user, selectedConversationId }: DashboardProps) => {
+const Dashboard = ({ children, user }: PropsWithChildren<DashboardProps>) => {
   useEffect(() => {
     window.scrollTo(0, 0)
   }, [])
@@ -138,11 +134,7 @@ const Dashboard = ({ user, selectedConversationId }: DashboardProps) => {
             <LogoBlock />
           </Box>
           <DashboardUserButton />
-          {selectedConversationId ? (
-            <DashboardConversation selectedConversationId={selectedConversationId} user={user} />
-          ) : (
-            <Placeholder />
-          )}
+          {children}
         </Box>
       </Flex>
       <CreateConversationModal

--- a/client/src/pages/dashboard/index.tsx
+++ b/client/src/pages/dashboard/index.tsx
@@ -1,24 +1,18 @@
 /** @jsx jsx */
 
 import React, { useEffect, useState } from "react"
-import { Link as RouterLink, useHistory, useLocation } from "react-router-dom"
+import { Link as RouterLink, useLocation } from "react-router-dom"
 import { Box, Flex, Text, jsx } from "theme-ui"
 import { toast } from "react-hot-toast"
-import { TbGitPullRequest } from "react-icons/tb"
-import { BiSolidBarChartAlt2 } from "react-icons/bi"
 
-import { formatTimeAgo } from "../../util/misc"
-import { useAppSelector } from "../../hooks"
-import { RootState } from "../../store"
 import api from "../../util/api"
 import { User } from "../../util/types"
 import { CreateConversationModal } from "../CreateConversationModal"
 import { DashboardConversation } from "./conversation"
 import { DashboardUserButton } from "./user_button"
-import ConversationsList, { getIconForConversation } from "./conversations_list"
-import { ConversationSummary } from "../../reducers/conversations_summary"
+import ConversationsList from "./conversations_list"
 
-export const MIN_SEED_RESPONSES = 5
+import { Placeholder } from "./placeholder"
 
 const LogoBlock = () => {
   return (
@@ -48,59 +42,6 @@ const LogoBlock = () => {
   )
 }
 
-const ConversationsPreview = ({ conversations }: { conversations: ConversationSummary[] }) => {
-  const hist = useHistory()
-
-  return (
-    <Box sx={{ pt: [3], ml: "26px" }}>
-      {conversations.length === 0 && (
-        <Box sx={{ fontWeight: 500, mt: [3], mb: [3], opacity: 0.5 }}>None found</Box>
-      )}
-      {conversations.map((c) => {
-        const date = new Date(c.fip_created || +c.created)
-        const timeAgo = formatTimeAgo(+date)
-
-        return (
-          <Flex
-            sx={{
-              bg: "bgWhite",
-              border: "1px solid #e2ddd599",
-              borderRadius: "8px",
-              px: [3],
-              py: "12px",
-              mb: [2],
-              lineHeight: 1.3,
-              cursor: "pointer",
-              "&:hover": {
-                border: "1px solid #e2ddd5",
-              },
-            }}
-            key={c.created}
-            onClick={() => hist.push(`/dashboard/c/${c.conversation_id}`)}
-          >
-            <Box sx={{ pr: "13px", pt: "1px" }}>
-              {c.github_pr_title ? (
-                getIconForConversation(c)
-              ) : (
-                <BiSolidBarChartAlt2 color="#0090ff" />
-              )}
-            </Box>
-            <Box>
-              <Box>
-                {c.github_pr_title && <Text sx={{ fontWeight: 600 }}>FIP: </Text>}
-                {c.fip_title || c.github_pr_title || c.topic}
-              </Box>
-              <Box sx={{ opacity: 0.6, fontSize: "0.94em", mt: "3px", fontWeight: 400 }}>
-                Created {timeAgo}
-              </Box>
-            </Box>
-          </Flex>
-        )
-      })}
-    </Box>
-  )
-}
-
 type DashboardProps = {
   user: User
   selectedConversationId: string | null
@@ -116,9 +57,6 @@ const Dashboard = ({ user, selectedConversationId }: DashboardProps) => {
   useEffect(() => {
     setMobileMenuOpen(false)
   }, [location])
-
-  const { data } = useAppSelector((state: RootState) => state.conversations_summary)
-  const conversations = data || []
 
   const [createConversationModalIsOpen, setCreateConversationModalIsOpen] = useState(false)
   const [syncInProgress, setSyncInProgress] = useState(false)
@@ -204,57 +142,7 @@ const Dashboard = ({ user, selectedConversationId }: DashboardProps) => {
           {selectedConversationId ? (
             <DashboardConversation selectedConversationId={selectedConversationId} user={user} />
           ) : (
-            <Box sx={{ maxWidth: [null, "540px"], px: [3], py: [3], pt: [8], margin: "0 auto" }}>
-              <Box>
-                Welcome to Metropolis, a nonbinding sentiment check tool for the Filecoin community.
-                You can:
-              </Box>
-              {/* FIPs */}
-              <Flex sx={{ pt: [3], mt: [3] }}>
-                <Box sx={{ flex: "0 0 25px" }}>
-                  <TbGitPullRequest color="#3fba50" style={{ marginRight: "6px" }} />
-                </Box>
-                <Box>
-                  <Text sx={{ fontWeight: 700 }}>Signal your position</Text> on FIPs through
-                  sentiment checks. <br />
-                  The following FIPs are currently open for sentiment checks:
-                </Box>
-              </Flex>
-              <ConversationsPreview
-                conversations={conversations
-                  .filter(
-                    (c) =>
-                      !c.is_archived && !c.is_hidden && c.github_pr_title && c.fip_files_created,
-                  )
-                  .slice(0, 5)}
-              />
-              {/* discussions */}
-              <Flex sx={{ pt: [3], mt: [3] }}>
-                <Box sx={{ flex: "0 0 25px" }}>
-                  <BiSolidBarChartAlt2 color="#0090ff" style={{ marginRight: "6px" }} />
-                </Box>
-                <Box>
-                  <Text sx={{ fontWeight: 700 }}>
-                    Initiate discussions, collect feedback, and respond to polls
-                  </Text>{" "}
-                  on open-ended thoughts or ideas.
-                </Box>
-              </Flex>
-              <Box sx={{ pt: [2], pl: "25px" }}>
-                The following discussion polls have been active recently:
-              </Box>
-              <ConversationsPreview
-                conversations={conversations
-                  .filter(
-                    (c) =>
-                      !c.is_archived &&
-                      !c.is_hidden &&
-                      !c.github_pr_title &&
-                      c.comment_count >= MIN_SEED_RESPONSES,
-                  )
-                  .slice(0, 5)}
-              />
-            </Box>
+            <Placeholder />
           )}
         </Box>
       </Flex>

--- a/client/src/pages/dashboard/index.tsx
+++ b/client/src/pages/dashboard/index.tsx
@@ -88,7 +88,7 @@ const Dashboard = ({ children, user }: PropsWithChildren<DashboardProps>) => {
             display: mobileMenuOpen ? null : ["none", "block"],
             width: ["100%", "40%", null, "340px"],
             borderRight: "1px solid #e2ddd5",
-            bg: "bgOffWhite",
+            bg: "#FFFFFF",
             maxHeight: "100vh",
             overflow: "hidden",
             position: "relative",
@@ -124,7 +124,7 @@ const Dashboard = ({ children, user }: PropsWithChildren<DashboardProps>) => {
             overflowY: "scroll",
             flex: 1,
             position: "relative",
-            bg: "bgDarkWhite",
+            bg: "#F9F9FB",
           }}
         >
           <Box

--- a/client/src/pages/dashboard/index.tsx
+++ b/client/src/pages/dashboard/index.tsx
@@ -116,7 +116,6 @@ const Dashboard = ({ user, selectedConversationId }: DashboardProps) => {
             </Box>
           </Flex>
           <ConversationsList
-            selectedConversationId={selectedConversationId}
             setCreateConversationModalIsOpen={setCreateConversationModalIsOpen}
             syncPRs={syncPRs}
             syncInProgress={syncInProgress}

--- a/client/src/pages/dashboard/list_selector.tsx
+++ b/client/src/pages/dashboard/list_selector.tsx
@@ -1,0 +1,101 @@
+import React from "react"
+import { Box, Flex, Text } from "theme-ui"
+import { TbDotsVertical } from "react-icons/tb"
+import { Menu } from "@headlessui/react"
+
+type Entry<T> = {
+  id: T
+  label: string
+  count: number
+}
+
+export const ListSelector = <T,>({
+  selectedEntryId,
+  setSelectedEntryId,
+  visibleEntries,
+  dropdownEntries,
+}: {
+  selectedEntryId: T
+  setSelectedEntryId: (id: T) => void
+  visibleEntries: Entry<T>[]
+  dropdownEntries: Entry<T>[]
+}) => {
+  const tab = {
+    mr: "6px",
+    px: "8px",
+    pt: "6px",
+    textAlign: "center",
+    color: "primary",
+    borderRadius: "10px",
+    border: "1px solid lightGray",
+    fontSize: "0.92em",
+    cursor: "pointer",
+    "&:hover": {
+      bg: "bgGrayLight",
+    },
+  }
+
+  const tabSelected = {
+    ...tab,
+    border: "1px solid primary",
+    bg: "primary",
+    color: "#fff",
+    "&:hover": {},
+  }
+
+  const tabCount = {
+    background: "primaryActive",
+    color: "#fff",
+    fontSize: "0.84em",
+    borderRadius: "99px",
+    px: "6px",
+    py: "3px",
+    ml: "2px",
+    top: "-1px",
+    position: "relative",
+  }
+
+  return (
+    <Flex sx={{ pt: "9px", pb: "8px", pl: "13px" }}>
+      {visibleEntries.map((entry) => (
+        <Box
+          sx={selectedEntryId === entry.id ? tabSelected : tab}
+          onClick={() => setSelectedEntryId(entry.id)}
+        >
+          {entry.label} <Text sx={tabCount}>{entry.count}</Text>
+        </Box>
+      ))}
+      <Box sx={{ flex: 1 }}></Box>
+      <Box>
+        <Menu>
+          <Menu.Button as="div">
+            <Box sx={{ px: "10px", py: "3px", my: "3px", mr: "5px", cursor: "pointer" }}>
+              <TbDotsVertical />
+            </Box>
+          </Menu.Button>
+          <Menu.Items as={Box}>
+            <Box variant="boxes.menu" sx={{ width: "180px" }}>
+              {dropdownEntries.map((entry) => (
+                <Menu.Item>
+                  <Box
+                    variant={
+                      selectedEntryId === entry.id ? "boxes.menuitemactive" : "boxes.menuitem"
+                    }
+                    onClick={() => setSelectedEntryId(entry.id)}
+                  >
+                    <Flex>
+                      <Box sx={{ flex: 1 }}> {entry.label}</Box>
+                      <Box sx={{ pr: [1], opacity: 0.6, fontSize: "0.93em", top: "1px" }}>
+                        {entry.count}
+                      </Box>
+                    </Flex>
+                  </Box>
+                </Menu.Item>
+              ))}
+            </Box>
+          </Menu.Items>
+        </Menu>
+      </Box>
+    </Flex>
+  )
+}

--- a/client/src/pages/dashboard/list_selector.tsx
+++ b/client/src/pages/dashboard/list_selector.tsx
@@ -59,6 +59,7 @@ export const ListSelector = <T,>({
     <Flex sx={{ pt: "9px", pb: "8px", pl: "13px" }}>
       {visibleEntries.map((entry) => (
         <Box
+          key={entry.id.toString()}
           sx={selectedEntryId === entry.id ? tabSelected : tab}
           onClick={() => setSelectedEntryId(entry.id)}
         >
@@ -76,7 +77,7 @@ export const ListSelector = <T,>({
           <Menu.Items as={Box}>
             <Box variant="boxes.menu" sx={{ width: "180px" }}>
               {dropdownEntries.map((entry) => (
-                <Menu.Item>
+                <Menu.Item key={entry.id.toString()}>
                   <Box
                     variant={
                       selectedEntryId === entry.id ? "boxes.menuitemactive" : "boxes.menuitem"

--- a/client/src/pages/dashboard/listing_selector.tsx
+++ b/client/src/pages/dashboard/listing_selector.tsx
@@ -1,0 +1,38 @@
+import React from "react"
+import { IconType } from "react-icons"
+import { Flex, Text } from "theme-ui"
+
+// TODO: we should decide on a better name for this concept
+export const ListingSelector = ({
+  iconType,
+  label,
+  isSelected,
+  onClick,
+}: {
+  iconType: IconType
+  label: string
+  isSelected: boolean
+  onClick: () => void
+}) => {
+  const iconComponent = iconType({ size: "1.5em", style: { position: "relative", top: 0 } })
+
+  return (
+    <Flex
+      onClick={onClick}
+      sx={{
+        m: 2,
+        p: 2,
+        borderRadius: "8px",
+        alignItems: "center",
+        gap: "8px",
+        cursor: "pointer",
+        userSelect: "none",
+        ...(isSelected ? { bg: "#D5EFFF", color: "#006BCA" } : { color: "#60646C" }),
+        // TODO: Add hover effect
+      }}
+    >
+      {iconComponent}
+      <Text sx={isSelected ? { fontWeight: 600 } : {}}>{label}</Text>
+    </Flex>
+  )
+}

--- a/client/src/pages/dashboard/listing_selector.tsx
+++ b/client/src/pages/dashboard/listing_selector.tsx
@@ -1,38 +1,40 @@
 import React from "react"
 import { IconType } from "react-icons"
+import { NavLink } from "react-router-dom-v5-compat"
 import { Flex, Text } from "theme-ui"
 
 // TODO: we should decide on a better name for this concept
 export const ListingSelector = ({
   iconType,
   label,
-  isSelected,
-  onClick,
+  to,
 }: {
   iconType: IconType
   label: string
-  isSelected: boolean
-  onClick: () => void
+  to: string
 }) => {
   const iconComponent = iconType({ size: "1.5em", style: { position: "relative", top: 0 } })
 
   return (
-    <Flex
-      onClick={onClick}
-      sx={{
-        m: 2,
-        p: 2,
-        borderRadius: "8px",
-        alignItems: "center",
-        gap: "8px",
-        cursor: "pointer",
-        userSelect: "none",
-        ...(isSelected ? { bg: "#D5EFFF", color: "#006BCA" } : { color: "#60646C" }),
-        // TODO: Add hover effect
-      }}
-    >
-      {iconComponent}
-      <Text sx={isSelected ? { fontWeight: 600 } : {}}>{label}</Text>
-    </Flex>
+    <NavLink to={to}>
+      {({ isActive }) => (
+        <Flex
+          sx={{
+            m: 2,
+            p: 2,
+            borderRadius: "8px",
+            alignItems: "center",
+            gap: "8px",
+            cursor: "pointer",
+            userSelect: "none",
+            ...(isActive ? { bg: "#D5EFFF", color: "#006BCA" } : { color: "#60646C" }),
+            // TODO: Add hover effect
+          }}
+        >
+          {iconComponent}
+          <Text sx={isActive ? { fontWeight: 600 } : {}}>{label}</Text>
+        </Flex>
+      )}
+    </NavLink>
   )
 }

--- a/client/src/pages/dashboard/placeholder.tsx
+++ b/client/src/pages/dashboard/placeholder.tsx
@@ -1,0 +1,121 @@
+import React from "react"
+
+import { TbGitPullRequest } from "react-icons/tb"
+import { BiSolidBarChartAlt2 } from "react-icons/bi"
+import { useHistory } from "react-router-dom"
+import { Box, Flex, Text } from "theme-ui"
+
+import { getIconForConversation } from "./conversations_list"
+import { useAppSelector } from "../../hooks"
+import { ConversationSummary } from "../../reducers/conversations_summary"
+import { RootState } from "../../store"
+import { formatTimeAgo, MIN_SEED_RESPONSES } from "../../util/misc"
+
+const ConversationsPreview = ({ conversations }: { conversations: ConversationSummary[] }) => {
+  const hist = useHistory()
+
+  return (
+    <Box sx={{ pt: [3], ml: "26px" }}>
+      {conversations.length === 0 && (
+        <Box sx={{ fontWeight: 500, mt: [3], mb: [3], opacity: 0.5 }}>None found</Box>
+      )}
+      {conversations.map((c) => {
+        const date = new Date(c.fip_created || +c.created)
+        const timeAgo = formatTimeAgo(+date)
+
+        return (
+          <Flex
+            sx={{
+              bg: "bgWhite",
+              border: "1px solid #e2ddd599",
+              borderRadius: "8px",
+              px: [3],
+              py: "12px",
+              mb: [2],
+              lineHeight: 1.3,
+              cursor: "pointer",
+              "&:hover": {
+                border: "1px solid #e2ddd5",
+              },
+            }}
+            key={c.created}
+            onClick={() => hist.push(`/dashboard/c/${c.conversation_id}`)}
+          >
+            <Box sx={{ pr: "13px", pt: "1px" }}>
+              {c.github_pr_title ? (
+                getIconForConversation(c)
+              ) : (
+                <BiSolidBarChartAlt2 color="#0090ff" />
+              )}
+            </Box>
+            <Box>
+              <Box>
+                {c.github_pr_title && <Text sx={{ fontWeight: 600 }}>FIP: </Text>}
+                {c.fip_title || c.github_pr_title || c.topic}
+              </Box>
+              <Box sx={{ opacity: 0.6, fontSize: "0.94em", mt: "3px", fontWeight: 400 }}>
+                Created {timeAgo}
+              </Box>
+            </Box>
+          </Flex>
+        )
+      })}
+    </Box>
+  )
+}
+
+export const Placeholder = () => {
+  const { data } = useAppSelector((state: RootState) => state.conversations_summary)
+  const conversations = data || []
+
+  return (
+    <Box sx={{ maxWidth: [null, "540px"], px: [3], py: [3], pt: [8], margin: "0 auto" }}>
+      <Box>
+        Welcome to Metropolis, a nonbinding sentiment check tool for the Filecoin community. You
+        can:
+      </Box>
+      {/* FIPs */}
+      <Flex sx={{ pt: [3], mt: [3] }}>
+        <Box sx={{ flex: "0 0 25px" }}>
+          <TbGitPullRequest color="#3fba50" style={{ marginRight: "6px" }} />
+        </Box>
+        <Box>
+          <Text sx={{ fontWeight: 700 }}>Signal your position</Text> on FIPs through sentiment
+          checks. <br />
+          The following FIPs are currently open for sentiment checks:
+        </Box>
+      </Flex>
+      <ConversationsPreview
+        conversations={conversations
+          .filter((c) => !c.is_archived && !c.is_hidden && c.github_pr_title && c.fip_files_created)
+          .slice(0, 5)}
+      />
+      {/* discussions */}
+      <Flex sx={{ pt: [3], mt: [3] }}>
+        <Box sx={{ flex: "0 0 25px" }}>
+          <BiSolidBarChartAlt2 color="#0090ff" style={{ marginRight: "6px" }} />
+        </Box>
+        <Box>
+          <Text sx={{ fontWeight: 700 }}>
+            Initiate discussions, collect feedback, and respond to polls
+          </Text>{" "}
+          on open-ended thoughts or ideas.
+        </Box>
+      </Flex>
+      <Box sx={{ pt: [2], pl: "25px" }}>
+        The following discussion polls have been active recently:
+      </Box>
+      <ConversationsPreview
+        conversations={conversations
+          .filter(
+            (c) =>
+              !c.is_archived &&
+              !c.is_hidden &&
+              !c.github_pr_title &&
+              c.comment_count >= MIN_SEED_RESPONSES,
+          )
+          .slice(0, 5)}
+      />
+    </Box>
+  )
+}

--- a/client/src/pages/dashboard/sentiment_checks.tsx
+++ b/client/src/pages/dashboard/sentiment_checks.tsx
@@ -1,0 +1,11 @@
+import React from "react"
+
+import { Box } from "theme-ui"
+
+export const SentimentChecks = () => {
+  return (
+    <Box sx={{ maxWidth: [null, "540px"], px: [3], py: [3], pt: [8], margin: "0 auto" }}>
+      <Box>Sentiment Checks</Box>
+    </Box>
+  )
+}

--- a/client/src/reducers/conversations_summary.ts
+++ b/client/src/reducers/conversations_summary.ts
@@ -21,6 +21,7 @@ export type ConversationSummary = {
   github_pr_is_draft: boolean
   github_pr_title: string | null
   github_pr_id: string | null
+  github_pr_url: string | null
   fip_files_created: string | null
   participant_count: number
   comment_count: number | null

--- a/client/src/util/misc.ts
+++ b/client/src/util/misc.ts
@@ -31,3 +31,7 @@ export const formatTimeAgo = (epochTime: number, short?: boolean) => {
     return val + (short ? `y` : ` year${val === 1 ? "" : "s"} ago`)
   }
 }
+
+// TODO: put this constant somewhere that is logically related to discussions
+// maybe it there should be a selector for "active conversations" that uses it
+export const MIN_SEED_RESPONSES = 5

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "react-popper": "^2.3.0",
         "react-redux": "^8.1.2",
         "react-router-dom": "^5.2.0",
+        "react-router-dom-v5-compat": "^6.26.0",
         "react-textarea-autosize": "^8.5.3",
         "redux": "^5.0.0",
         "redux-thunk": "~2.3.0",
@@ -865,42 +866,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
-    },
-    "client/node_modules/react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "client/node_modules/react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
     },
     "client/node_modules/redux": {
       "version": "5.0.1",
@@ -3896,6 +3861,14 @@
       "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
       "peerDependencies": {
         "redux": "^5.0.0"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.0.tgz",
+      "integrity": "sha512-zDICCLKEwbVYTS6TjYaWtHXxkdoUvD/QXvyVZjGCsWz5vyH7aFeONlPffPdW+Y/t6KT0MgXb2Mfjun9YpWN1dA==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -13815,6 +13788,82 @@
         "@popperjs/core": "^2.0.0",
         "react": "^16.8.0 || ^17 || ^18",
         "react-dom": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
+      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=15"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
+      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.3.4",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=15"
+      }
+    },
+    "node_modules/react-router-dom-v5-compat": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.26.0.tgz",
+      "integrity": "sha512-s0x2VvKex2JpOCIcnODVVSe6nN6uNtpcSUo9co+0K44PKt1z4QsYheF+W0mx/w64cYOh9b1P5c8YlfLg3X1XGg==",
+      "dependencies": {
+        "@remix-run/router": "1.19.0",
+        "history": "^5.3.0",
+        "react-router": "6.26.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8",
+        "react-router-dom": "4 || 5"
+      }
+    },
+    "node_modules/react-router-dom-v5-compat/node_modules/history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
+    "node_modules/react-router-dom-v5-compat/node_modules/react-router": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.0.tgz",
+      "integrity": "sha512-wVQq0/iFYd3iZ9H2l3N3k4PL8EEHcb0XlU2Na8nEwmiXgIUElEH6gaJDtUQxJ+JFzmIXaQjfdpcGWaM6IoQGxg==",
+      "dependencies": {
+        "@remix-run/router": "1.19.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
       }
     },
     "node_modules/react-textarea-autosize": {
@@ -24664,6 +24713,11 @@
         }
       }
     },
+    "@remix-run/router": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.0.tgz",
+      "integrity": "sha512-zDICCLKEwbVYTS6TjYaWtHXxkdoUvD/QXvyVZjGCsWz5vyH7aFeONlPffPdW+Y/t6KT0MgXb2Mfjun9YpWN1dA=="
+    },
     "@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -30043,6 +30097,7 @@
         "react-popper": "^2.3.0",
         "react-redux": "^8.1.2",
         "react-router-dom": "^5.2.0",
+        "react-router-dom-v5-compat": "^6.26.0",
         "react-textarea-autosize": "^8.5.3",
         "redux": "^5.0.0",
         "redux-thunk": "~2.3.0",
@@ -30629,36 +30684,6 @@
               "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
               "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
             }
-          }
-        },
-        "react-router": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-          "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
-          "requires": {
-            "@babel/runtime": "^7.12.13",
-            "history": "^4.9.0",
-            "hoist-non-react-statics": "^3.1.0",
-            "loose-envify": "^1.3.1",
-            "path-to-regexp": "^1.7.0",
-            "prop-types": "^15.6.2",
-            "react-is": "^16.6.0",
-            "tiny-invariant": "^1.0.2",
-            "tiny-warning": "^1.0.0"
-          }
-        },
-        "react-router-dom": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-          "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
-          "requires": {
-            "@babel/runtime": "^7.12.13",
-            "history": "^4.9.0",
-            "loose-envify": "^1.3.1",
-            "prop-types": "^15.6.2",
-            "react-router": "5.3.4",
-            "tiny-invariant": "^1.0.2",
-            "tiny-warning": "^1.0.0"
           }
         },
         "redux": {
@@ -35348,6 +35373,64 @@
       "requires": {
         "react-fast-compare": "^3.0.1",
         "warning": "^4.0.2"
+      }
+    },
+    "react-router": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
+      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+      "requires": {
+        "@babel/runtime": "^7.12.13",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
+      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.13",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.3.4",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      }
+    },
+    "react-router-dom-v5-compat": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.26.0.tgz",
+      "integrity": "sha512-s0x2VvKex2JpOCIcnODVVSe6nN6uNtpcSUo9co+0K44PKt1z4QsYheF+W0mx/w64cYOh9b1P5c8YlfLg3X1XGg==",
+      "requires": {
+        "@remix-run/router": "1.19.0",
+        "history": "^5.3.0",
+        "react-router": "6.26.0"
+      },
+      "dependencies": {
+        "history": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+          "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+          "requires": {
+            "@babel/runtime": "^7.7.6"
+          }
+        },
+        "react-router": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.0.tgz",
+          "integrity": "sha512-wVQq0/iFYd3iZ9H2l3N3k4PL8EEHcb0XlU2Na8nEwmiXgIUElEH6gaJDtUQxJ+JFzmIXaQjfdpcGWaM6IoQGxg==",
+          "requires": {
+            "@remix-run/router": "1.19.0"
+          }
+        }
       }
     },
     "react-textarea-autosize": {


### PR DESCRIPTION
This PR implements the new FIP Tracker interface.

- Upgrade React Router to version 6 - I'm using `react-router-dom-compat` which lets us upgrade from v5 to v6 in a piecemeal fashion, this is the officially recommended approach. I wanted to do this so that we can take advantage of making `NavLink` components for divs (the version of `NavLink` in v5 only supports `a` tags).
- Refactor the `Dashboard` component so that the content can be passed in via the `children` prop
- Create links in the sidebar for "Sentiment Checks" and "FIP Tracker"

## To do:

- [x] Display the FIP number
- [x] Link to GitHub PR
- [x] FIP status
- [ ] Change the colour of the FIP div based on the status
- [ ] Category tags
- [x] Creation date
- [x] Authors
- [ ] When the user clicks on a FIP entry, expand the div so that it shows the FIP contents in more detail
- [ ] Allow user to search FIPs
- [ ] Allow user to filter FIPs


Current WIP:

![Screenshot 2024-08-14 at 9 37 45 PM](https://github.com/user-attachments/assets/13373d63-20c3-4338-a08f-0a15c54531fb)

