### PR TITLE
FIP tracker: strip trailing comma from authors list

### DIFF
--- a/client/src/pages/dashboard/fip_tracker/index.tsx
+++ b/client/src/pages/dashboard/fip_tracker/index.tsx
@@ -27,7 +27,7 @@ const splitAuthors = (authorList = "") => {
       "<a list of the author's or authors' name(s) and/or username(s), or name(s) and email(s), e.g. (use with the parentheses or triangular brackets):",
       "",
     )
-    .replace(/"/g, "")
+    .replace(/"|,$/g, "")
     .split(/, | and /)
   if (result && result.length === 1) {
     return result[0].split(/ @/).map((i) => {


### PR DESCRIPTION
Issue: https://github.com/canvasxyz/metropolis/issues/52

When we display the FIP in the FIP tracker, we look up the "Authors" field in the FIP Markdown frontmatter. We then process this string in order to obtain a list of GitHub usernames. We encountered a bug where if the input string has a trailing comma, this comma is displayed in the FIP Tracker (see the "Authors" section in the expanded FIP view): 

![Screenshot 2024-10-23 at 2 33 25 PM](https://github.com/user-attachments/assets/6957cd3c-6958-42d9-9f3c-3d0345b99ee6)

This PR updates the "splitAuthors" function so that it strips out the trailing comma.