### PR TITLE
FIP Tracker: Update filters and display button icons to match text

### DIFF
--- a/client/src/pages/dashboard/fip_tracker/index.tsx
+++ b/client/src/pages/dashboard/fip_tracker/index.tsx
@@ -212,7 +212,7 @@ export default ({ user }: { user: any }) => {
         <DropdownMenu.Root>
           <DropdownMenu.Trigger>
             <RadixButton variant="surface">
-              <BiFilter size="1.1em" style={{ color: "#B6B8C4", top: "-1px" }} />
+              <BiFilter size="1.1em" style={{ color: "var(--accent-a11)", top: "-1px" }} />
               Filters
             </RadixButton>
           </DropdownMenu.Trigger>
@@ -303,7 +303,7 @@ export default ({ user }: { user: any }) => {
         <DropdownMenu.Root>
           <DropdownMenu.Trigger>
             <RadixButton variant="surface">
-              <TbAdjustmentsHorizontal style={{ color: "#B6B8C4" }} />
+              <TbAdjustmentsHorizontal style={{ color: "var(--accent-a11)" }} />
               Display
             </RadixButton>
           </DropdownMenu.Trigger>


### PR DESCRIPTION
Issue: https://github.com/canvasxyz/metropolis/issues/49

The icon colors now match the text - I used `var(--accent-a11)` to match the color set by Radix UI.

![Screenshot 2024-10-23 at 3 30 27 PM](https://github.com/user-attachments/assets/50e3949c-6cba-44f0-aaf8-9b0d8b4f27a8)
