### PR TITLE
FIP Tracker: fix bug where date picker does not always disappear when unfocused

### DIFF
--- a/client/src/pages/dashboard/fip_tracker/date_picker.tsx
+++ b/client/src/pages/dashboard/fip_tracker/date_picker.tsx
@@ -116,7 +116,11 @@ export const DatePicker = ({
           <Button
             color="red"
             variant="soft"
-            onClick={() => onRangeValueChange({ start: null, end: null })}
+            onClick={(e) => {
+              onRangeValueChange({ start: null, end: null })
+              // @ts-expect-error - blur is a valid method
+              e.target.blur()
+            }}
           >
             Clear
           </Button>


### PR DESCRIPTION
Fixes https://github.com/canvasxyz/metropolis/issues/50

The fix here is to explicitly call `e.target.blur()` on the "Clear" button when it is clicked.