### PR TITLE
Handle when Simple Summary has multiple paragraphs

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -82,6 +82,10 @@
       text-decoration: underline;
     }
 
+    .react-markdown img {
+      max-width: 100%;
+    }
+
     .react-markdown h1,
     .react-markdown h2,
     .react-markdown h3,

--- a/client/src/pages/dashboard/fip_tracker/fip_entry.tsx
+++ b/client/src/pages/dashboard/fip_tracker/fip_entry.tsx
@@ -50,9 +50,6 @@ const FipEntryInner = ({
                 </React.Fragment>
               )
             })}
-
-        <h3 style={{ margin: "15px 0 10px" }}>Simple Summary</h3>
-
         <div
           onClick={(e) => {
             // It's possible that there could be a tag inside the link,

--- a/client/src/pages/dashboard/fip_tracker/simple_summary.tsx
+++ b/client/src/pages/dashboard/fip_tracker/simple_summary.tsx
@@ -4,6 +4,7 @@ import remarkGfm from "remark-gfm"
 import markdown from "remark-parse"
 import { remark } from "remark"
 import { unified } from "unified"
+import { Box } from "theme-ui"
 
 export const extractParagraphByTitle = (markdownText, title) => {
   const tree = unified().use(markdown).parse(markdownText)
@@ -44,6 +45,32 @@ export const extractParagraphByTitle = (markdownText, title) => {
   return extractedNodes.map(node => remark().stringify(node)).join("\n")
 }
 
+export const extractFirstSection = (markdownText) => {
+  const tree = unified().use(markdown).parse(markdownText)
+
+  let titleDepth: number | null = null
+  let foundHeading = false
+  const extractedNodes: typeof tree.children = []
+
+  for(const node of tree.children) {
+    if(foundHeading) {
+      if (node.type === "heading" && node.depth <= titleDepth) {
+        // Stop if an equally or more important heading is found
+        break
+      }
+      extractedNodes.push(node)
+    } else {
+      if (node.type === "heading") {
+          foundHeading = true
+          titleDepth = node.depth
+      }
+    }
+  }
+
+  return extractedNodes.map(node => remark().stringify(node)).join("\n")
+}
+
+
 type SimpleSummaryProps = {
   content: string
 }
@@ -60,19 +87,27 @@ const SimpleSummary = ({ content }: SimpleSummaryProps) => {
     if (summaryContent)  {
       return { title: "Summary", content: summaryContent }
     }
+
+    const firstSectionContent = extractFirstSection(content)
+    if (firstSectionContent) {
+      return { title: null, content: firstSectionContent }
+    }
+
   }, [content])
 
   if (extractedData) {
     return <React.Fragment>
-      <h3 style={{ margin: "15px 0 10px" }}>{extractedData.title}</h3>
-      <ReactMarkdown
-        skipHtml={true}
-        remarkPlugins={[remarkGfm]}
-        linkTarget="_blank"
-        className="react-markdown"
-      >
-        {extractedData.content}
-      </ReactMarkdown>
+      {extractedData.title !== null && <h3>{extractedData.title}</h3>}
+      <Box sx={{mt: [2]}}>
+        <ReactMarkdown
+          skipHtml={true}
+          remarkPlugins={[remarkGfm]}
+          linkTarget="_blank"
+          className="react-markdown"
+        >
+          {extractedData.content}
+        </ReactMarkdown>
+      </Box>
     </React.Fragment>
   } else {
     return <React.Fragment>

--- a/client/src/pages/dashboard/fip_tracker/simple_summary.tsx
+++ b/client/src/pages/dashboard/fip_tracker/simple_summary.tsx
@@ -50,46 +50,28 @@ type SimpleSummaryProps = {
 
 const SimpleSummary = ({ content }: SimpleSummaryProps) => {
 
-  const [hasSimpleSummary, simpleSummaryText] = useMemo(() => {
-    const extractedData = extractParagraphByTitle(content, "Simple Summary")
-    if(extractedData)  {
-      return [true, extractedData]
-    } else {
-      return [false, content]
+  const extractedData = useMemo(() => {
+    const simpleSummaryContent = extractParagraphByTitle(content, "Simple Summary")
+    if (simpleSummaryContent)  {
+      return { title: "Simple Summary", content: simpleSummaryContent }
+    }
+
+    const summaryContent = extractParagraphByTitle(content, "Summary")
+    if (summaryContent)  {
+      return { title: "Summary", content: summaryContent }
     }
   }, [content])
 
-  const [hasSummary, summaryText] = useMemo(() => {
-    const extractedData = extractParagraphByTitle(content, "Summary")
-    if(extractedData)  {
-      return [true, extractedData]
-    } else {
-      return [false, content]
-    }
-  }, [content])
-
-  if (hasSimpleSummary) {
+  if (extractedData) {
     return <React.Fragment>
-      <h3 style={{ margin: "15px 0 10px" }}>Simple Summary</h3>
+      <h3 style={{ margin: "15px 0 10px" }}>{extractedData.title}</h3>
       <ReactMarkdown
         skipHtml={true}
         remarkPlugins={[remarkGfm]}
         linkTarget="_blank"
         className="react-markdown"
       >
-        {simpleSummaryText}
-      </ReactMarkdown>
-    </React.Fragment>
-  } else if (hasSummary) {
-    return <React.Fragment>
-      <h3 style={{ margin: "15px 0 10px" }}>Summary</h3>
-      <ReactMarkdown
-        skipHtml={true}
-        remarkPlugins={[remarkGfm]}
-        linkTarget="_blank"
-        className="react-markdown"
-      >
-        {summaryText}
+        {extractedData.content}
       </ReactMarkdown>
     </React.Fragment>
   } else {


### PR DESCRIPTION
This PR updates the "Simple Summary" algorithm to handle cases when the Simple Summary contains multiple paragraphs. In addition, if a "Simple Summary" heading does not exist, it falls back to checking for a "Summary" heading. If there isn't a "Summary" heading, it just returns whatever is between the first and second headings in the document.