### PR TITLE
Landing page updates

### DIFF
--- a/client/src/pages/dashboard/conversations_list.tsx
+++ b/client/src/pages/dashboard/conversations_list.tsx
@@ -208,30 +208,26 @@ const ConversationsList = ({
           </Link>
         </Box>
       )}
-      <Button
-        variant={user ? "buttons.primary" : "buttons.black"}
-        sx={{
-          px: [2],
-          py: [1],
-          mr: [1],
-          mb: [1],
-          position: "absolute",
-          bottom: "40px",
-          right: "11px",
-          fontSize: "0.94em",
-          width: "calc(100% - 32px)",
-          fontWeight: 500,
-        }}
-        onClick={() => {
-          if (user) {
-            setCreateConversationModalIsOpen(true)
-          } else {
-            document.location = `/api/v3/github_oauth_init?dest=${window.location.href}`
-          }
-        }}
-      >
-        {user ? <BiSolidBarChartAlt2 /> : null} {user ? "Create a poll" : "Sign in with Github"}
-      </Button>
+      {user && (
+        <Button
+          variant="buttons.primary"
+          sx={{
+            px: [2],
+            py: [1],
+            mr: [1],
+            mb: [1],
+            position: "absolute",
+            bottom: "40px",
+            right: "11px",
+            fontSize: "0.94em",
+            width: "calc(100% - 32px)",
+            fontWeight: 500,
+          }}
+          onClick={() => setCreateConversationModalIsOpen(true)}
+        >
+          <BiSolidBarChartAlt2 />Create a poll
+        </Button>
+      )}
       <Box
         sx={{
           textAlign: "center",

--- a/client/src/pages/dashboard/conversations_list.tsx
+++ b/client/src/pages/dashboard/conversations_list.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from "react"
 import { useLocalStorage } from "usehooks-ts"
-import { Button, Box, Text, Link } from "theme-ui"
-import { Link as RouterLink } from "react-router-dom"
+import { Button, Box, Link } from "theme-ui"
 import { TbExternalLink, TbFocus } from "react-icons/tb"
 import { BiSolidBarChartAlt2 } from "react-icons/bi"
 
@@ -244,10 +243,6 @@ const ConversationsList = ({
           borderTop: "1px solid lighterGray",
         }}
       >
-        <RouterLink to="/about">
-          <Text variant="links.a">About</Text>
-        </RouterLink>{" "}
-        &middot;{" "}
         <Link
           variant="links.a"
           as="a"

--- a/client/src/pages/dashboard/fip_tracker/fip_entry.tsx
+++ b/client/src/pages/dashboard/fip_tracker/fip_entry.tsx
@@ -54,6 +54,7 @@ const FipEntryInner = ({
           onClick={(e) => {
             // It's possible that there could be a tag inside the link,
             // but we don't handle that case here
+            // @ts-expect-error - TS doesn't know about tagName
             if (e.target.tagName === "A") {
               e.stopPropagation()
             }

--- a/client/src/pages/dashboard/index.tsx
+++ b/client/src/pages/dashboard/index.tsx
@@ -11,7 +11,7 @@ import { User } from "../../util/types"
 import { CreateConversationModal } from "../CreateConversationModal"
 import { DashboardUserButton } from "./user_button"
 import ConversationsList from "./conversations_list"
-import { Placeholder } from "./placeholder"
+import { LandingPage } from "./landing_page"
 import { DashboardConversation } from "./conversation"
 const SentimentChecks = React.lazy(() => import("./sentiment_checks"))
 const FipTracker = React.lazy(() => import("./fip_tracker/index.js"))
@@ -140,7 +140,7 @@ const Dashboard = ({ user }: DashboardProps) => {
           </Box>
           <DashboardUserButton />
           <CompatRoutes>
-            <CompatRoute path="/" element={<Placeholder />} />
+            <CompatRoute path="/" element={<LandingPage />} />
             <CompatRoute path="/sentiment_checks" element={
               <Suspense>
                 {" "}

--- a/client/src/pages/dashboard/landing_page.tsx
+++ b/client/src/pages/dashboard/landing_page.tsx
@@ -69,7 +69,7 @@ export const LandingPage = () => {
 
   return (
     <Box>
-      <Container size="3" mt="4">
+      <Container size="3" mt="4" px="3">
         <Flex
           direction="column"
           align="center"
@@ -86,7 +86,7 @@ export const LandingPage = () => {
           </Box>
           A nonbinding sentiment check tool for the Filecoin community.
         </Flex>
-        <Grid columns="2" gap="4" py="6">
+        <Grid columns={{initial: "1", md: "2"}} gap="4" py="6">
           {/* discussions */}
           <Card>
             <Flex direction="column" gap="4" mx="2" mt="3">
@@ -104,9 +104,7 @@ export const LandingPage = () => {
                 </Box>
               </Flex>
               <Separator size="4"/>
-
-                The following discussion polls have been active recently:
-
+              The following discussion polls have been active recently:
               <ConversationsPreview
                 conversations={conversations
                   .filter(
@@ -131,8 +129,7 @@ export const LandingPage = () => {
                 </Box>
                 <Box>
                   <Text weight="bold">Signal your position</Text> on FIPs through sentiment
-                  checks. <br />
-
+                  checks.
                 </Box>
               </Flex>
               <Separator size="4"/>

--- a/client/src/pages/dashboard/landing_page.tsx
+++ b/client/src/pages/dashboard/landing_page.tsx
@@ -3,13 +3,45 @@ import React from "react"
 import { TbGitPullRequest } from "react-icons/tb"
 import { BiSolidBarChartAlt2 } from "react-icons/bi"
 import { Link as RouterLink, useHistory } from "react-router-dom"
-import { Box, Card, Container, Flex, Grid, Separator, Text } from "@radix-ui/themes"
+import { Box, Container, Flex, Grid, Separator, Text } from "@radix-ui/themes"
 
 import { useAppSelector } from "../../hooks"
 import { ConversationSummary } from "../../reducers/conversations_summary"
 import { RootState } from "../../store"
 import { formatTimeAgo, MIN_SEED_RESPONSES } from "../../util/misc"
 import { getIconForConversation } from "./conversation_list_item"
+
+const SectionCard = ({ children }: { children: React.ReactNode }) =>
+  <div
+    style={{
+      borderColor: "#E8E8EB",
+      borderRadius: "16px",
+      borderStyle: "solid",
+      borderWidth: "1px",
+      padding: "6px",
+      background: "#fff",
+      fontSize: "95%",
+    }}
+  >
+    {children}
+  </div>
+
+const ConversationCard = ({ children, onClick }: { children: React.ReactNode; onClick: () => void }) =>
+  <div
+    style={{
+      borderColor: "#E8E8EB",
+      borderRadius: "8px",
+      borderStyle: "solid",
+      borderWidth: "1px",
+      padding: "6px",
+      background: "#fff",
+      fontSize: "95%",
+    }}
+    onClick={onClick}
+  >
+    {children}
+  </div>
+
 
 const ConversationsPreview = ({ conversations }: { conversations: ConversationSummary[] }) => {
   const hist = useHistory()
@@ -25,7 +57,7 @@ const ConversationsPreview = ({ conversations }: { conversations: ConversationSu
         const fipVersion = c.fip_version
 
         return (
-          <Card
+          <ConversationCard
             key={c.created}
             onClick={() => hist.push(`/dashboard/c/${c.conversation_id}`)}
           >
@@ -56,7 +88,7 @@ const ConversationsPreview = ({ conversations }: { conversations: ConversationSu
                 </Box>
               </Box>
             </Flex>
-          </Card>
+          </ConversationCard>
         )
       })}
     </Flex>
@@ -88,7 +120,7 @@ export const LandingPage = () => {
         </Flex>
         <Grid columns={{initial: "1", md: "2"}} gap="4" py="6">
           {/* discussions */}
-          <Card>
+          <SectionCard>
             <Flex direction="column" gap="4" mx="2" mt="3">
               <Flex gap="3">
                 <Box>
@@ -119,9 +151,9 @@ export const LandingPage = () => {
                   .slice(0, 5)}
               />
             </Flex>
-          </Card>
+          </SectionCard>
           {/* FIPs */}
-          <Card>
+          <SectionCard>
             <Flex direction="column" gap="4" mx="2" mt="3">
               <Flex gap="3">
                 <Box>
@@ -144,7 +176,7 @@ export const LandingPage = () => {
                   .slice(0, 5)}
               />
             </Flex>
-          </Card>
+          </SectionCard>
         </Grid>
       </Container>
       {/* footer */}

--- a/client/src/pages/dashboard/landing_page.tsx
+++ b/client/src/pages/dashboard/landing_page.tsx
@@ -49,8 +49,8 @@ const ConversationsPreview = ({ conversations }: { conversations: ConversationSu
                   c.topic
                 }
                 </Box>
-                <Box mt="3px">
-                  <Text size="2">
+                <Box>
+                  <Text size="2" color="gray">
                     Created {timeAgo}
                   </Text>
                 </Box>

--- a/client/src/pages/dashboard/landing_page.tsx
+++ b/client/src/pages/dashboard/landing_page.tsx
@@ -18,7 +18,7 @@ const SectionCard = ({ children }: { children: React.ReactNode }) =>
       borderRadius: "16px",
       borderStyle: "solid",
       borderWidth: "1px",
-      padding: "6px 6px 12px 6px",
+      padding: "6px 12px 18px 12px",
       background: "#fff",
       fontSize: "95%",
     }}
@@ -33,7 +33,7 @@ const ConversationCard = ({ children, onClick }: { children: React.ReactNode; on
       borderRadius: "8px",
       borderStyle: "solid",
       borderWidth: "1px",
-      padding: "6px",
+      padding: "8px",
       background: "#fff",
       fontSize: "95%",
     }}

--- a/client/src/pages/dashboard/landing_page.tsx
+++ b/client/src/pages/dashboard/landing_page.tsx
@@ -22,27 +22,16 @@ const ConversationsPreview = ({ conversations }: { conversations: ConversationSu
       {conversations.map((c) => {
         const date = new Date(c.fip_version?.fip_created || +c.created)
         const timeAgo = formatTimeAgo(+date)
+        const fipVersion = c.fip_version
 
         return (
-          <Card key={c.created}>
-            <Flex
-              sx={{
-                bg: "bgWhite",
-                border: "1px solid #e2ddd599",
-                borderRadius: "8px",
-                px: [3],
-                py: "12px",
-                mb: [2],
-                lineHeight: 1.3,
-                cursor: "pointer",
-                "&:hover": {
-                  border: "1px solid #e2ddd5",
-                },
-              }}
-              onClick={() => hist.push(`/dashboard/c/${c.conversation_id}`)}
-            >
+          <Card
+            key={c.created}
+            onClick={() => hist.push(`/dashboard/c/${c.conversation_id}`)}
+          >
+            <Flex>
               <Box pr="13px" pt="1px">
-                {c.fip_version?.github_pr?.title ? (
+                {fipVersion?.github_pr?.title ? (
                   getIconForConversation(c)
                 ) : (
                   <BiSolidBarChartAlt2 color="#0090ff" />
@@ -50,8 +39,13 @@ const ConversationsPreview = ({ conversations }: { conversations: ConversationSu
               </Box>
               <Box>
                 <Box>
-                  {c.fip_version?.github_pr?.title && <Text sx={{ fontWeight: 600 }}>FIP: </Text>}
-                  {c.fip_version?.fip_title || c.fip_version?.github_pr?.title || c.topic}
+                {fipVersion ?
+                  <React.Fragment>
+                    <Text weight="bold">FIP{fipVersion.fip_number ? String(fipVersion.fip_number).padStart(4, "0") : ""}: </Text>
+                    {fipVersion.fip_title || fipVersion.github_pr?.title}
+                  </React.Fragment> :
+                  c.topic
+                }
                 </Box>
                 <Box mt="3px">
                   <Text size="2">
@@ -88,20 +82,16 @@ export const LandingPage = () => {
           <Box pb="3" pt="3">
             <Text size="6" weight="bold" >Welcome to Fil Poll</Text>
           </Box>
-          <Text sx={{ }}>
-            A nonbinding sentiment check tool for the Filecoin community.
-          </Text>
+          A nonbinding sentiment check tool for the Filecoin community.
         </Flex>
         <Grid columns="2" gap="4" py="6">
           {/* discussions */}
           <Card>
             <Flex direction="column" gap="3" mx="2" mt="3">
               <Flex>
-                <Box sx={{ flex: "0 0 25px" }}>
-                  <BiSolidBarChartAlt2 color="#0090ff" style={{ marginRight: "6px" }} />
-                </Box>
+                <BiSolidBarChartAlt2 color="#0090ff" style={{ marginRight: "6px" }} />
                 <Box>
-                  <Text sx={{ fontWeight: 700 }}>
+                  <Text weight="bold">
                     Initiate discussions, collect feedback, and respond to polls
                   </Text>{" "}
                   on open-ended thoughts or ideas.
@@ -128,11 +118,9 @@ export const LandingPage = () => {
           <Card>
             <Flex direction="column" gap="3" mx="2" mt="3">
               <Flex>
-                <Box sx={{ flex: "0 0 25px" }}>
-                  <TbGitPullRequest color="#3fba50" style={{ marginRight: "6px" }} />
-                </Box>
+                <TbGitPullRequest color="#3fba50" style={{ marginRight: "6px" }} />
                 <Box>
-                  <Text sx={{ fontWeight: 700 }}>Signal your position</Text> on FIPs through sentiment
+                  <Text weight="bold">Signal your position</Text> on FIPs through sentiment
                   checks. <br />
 
                 </Box>

--- a/client/src/pages/dashboard/landing_page.tsx
+++ b/client/src/pages/dashboard/landing_page.tsx
@@ -104,7 +104,9 @@ export const LandingPage = () => {
                 </Box>
               </Flex>
               <Separator size="4"/>
-              The following discussion polls have been active recently:
+              <Text size="2">
+                The following discussion polls have been active recently:
+              </Text>
               <ConversationsPreview
                 conversations={conversations
                   .filter(
@@ -133,7 +135,9 @@ export const LandingPage = () => {
                 </Box>
               </Flex>
               <Separator size="4"/>
-              The following FIPs are currently open for sentiment checks:
+              <Text size="2">
+                The following FIPs are currently open for sentiment checks:
+              </Text>
               <ConversationsPreview
                 conversations={conversations
                   .filter((c) => !c.is_archived && !c.is_hidden && c.fip_version?.github_pr?.title && c.fip_version?.fip_files_created)

--- a/client/src/pages/dashboard/landing_page.tsx
+++ b/client/src/pages/dashboard/landing_page.tsx
@@ -64,7 +64,7 @@ const ConversationsPreview = ({ conversations }: { conversations: ConversationSu
   )
 }
 
-export const Placeholder = () => {
+export const LandingPage = () => {
   const { data } = useAppSelector((state: RootState) => state.conversations_summary)
   const conversations = data || []
 

--- a/client/src/pages/dashboard/landing_page.tsx
+++ b/client/src/pages/dashboard/landing_page.tsx
@@ -3,8 +3,7 @@ import React from "react"
 import { TbGitPullRequest } from "react-icons/tb"
 import { BiSolidBarChartAlt2 } from "react-icons/bi"
 import { Link as RouterLink, useHistory } from "react-router-dom"
-import { Card, Container, Flex, Grid, Link, Separator } from "@radix-ui/themes"
-import { Box, Image, Text } from "theme-ui"
+import { Box, Card, Container, Flex, Grid, Separator, Text } from "@radix-ui/themes"
 
 import { useAppSelector } from "../../hooks"
 import { ConversationSummary } from "../../reducers/conversations_summary"
@@ -18,7 +17,7 @@ const ConversationsPreview = ({ conversations }: { conversations: ConversationSu
   return (
     <Flex direction="column" gap="3">
       {conversations.length === 0 && (
-        <Box sx={{ fontWeight: 500, mt: [3], mb: [3], opacity: 0.5 }}>None found</Box>
+        <Box mt="3" mb="3"><Text weight="bold">None found</Text></Box>
       )}
       {conversations.map((c) => {
         const date = new Date(c.fip_version?.fip_created || +c.created)
@@ -42,7 +41,7 @@ const ConversationsPreview = ({ conversations }: { conversations: ConversationSu
               }}
               onClick={() => hist.push(`/dashboard/c/${c.conversation_id}`)}
             >
-              <Box sx={{ pr: "13px", pt: "1px" }}>
+              <Box pr="13px" pt="1px">
                 {c.fip_version?.github_pr?.title ? (
                   getIconForConversation(c)
                 ) : (
@@ -54,8 +53,10 @@ const ConversationsPreview = ({ conversations }: { conversations: ConversationSu
                   {c.fip_version?.github_pr?.title && <Text sx={{ fontWeight: 600 }}>FIP: </Text>}
                   {c.fip_version?.fip_title || c.fip_version?.github_pr?.title || c.topic}
                 </Box>
-                <Box sx={{ opacity: 0.6, fontSize: "0.94em", mt: "3px", fontWeight: 400 }}>
-                  Created {timeAgo}
+                <Box mt="3px">
+                  <Text size="2">
+                    Created {timeAgo}
+                  </Text>
                 </Box>
               </Box>
             </Flex>
@@ -79,18 +80,14 @@ export const LandingPage = () => {
           justify="center"
           pt="8"
         >
-          <Image
+          <img
             src="/filecoin.png"
             width="80px"
             height="80px"
-            sx={{paddingBottom: 3}}
           />
-          <Text sx={{
-            fontSize: 4,
-            fontWeight: "bold",
-            paddingBottom: 3,
-
-          }}>Welcome to Fil Poll</Text>
+          <Box pb="3" pt="3">
+            <Text size="6" weight="bold" >Welcome to Fil Poll</Text>
+          </Box>
           <Text sx={{ }}>
             A nonbinding sentiment check tool for the Filecoin community.
           </Text>
@@ -154,9 +151,9 @@ export const LandingPage = () => {
       {/* footer */}
       <Flex p="4" direction="row">
         <RouterLink to="/about">
-          <Link weight="bold">About Fil Poll</Link>
+          <Text weight="bold">About Fil Poll</Text>
         </RouterLink>
-        <Box sx={{ flex: "1 1 auto" }} />
+        <Box flexGrow="1"/>
         Fil Poll &copy; 2024
       </Flex>
     </Box>

--- a/client/src/pages/dashboard/landing_page.tsx
+++ b/client/src/pages/dashboard/landing_page.tsx
@@ -18,7 +18,7 @@ const SectionCard = ({ children }: { children: React.ReactNode }) =>
       borderRadius: "16px",
       borderStyle: "solid",
       borderWidth: "1px",
-      padding: "6px",
+      padding: "6px 6px 12px 6px",
       background: "#fff",
       fontSize: "95%",
     }}

--- a/client/src/pages/dashboard/landing_page.tsx
+++ b/client/src/pages/dashboard/landing_page.tsx
@@ -3,19 +3,20 @@ import React from "react"
 import { TbGitPullRequest } from "react-icons/tb"
 import { BiSolidBarChartAlt2 } from "react-icons/bi"
 import { useHistory } from "react-router-dom"
-import { Box, Flex, Image, Text } from "theme-ui"
+import { Box, Image, Text } from "theme-ui"
 
 import { useAppSelector } from "../../hooks"
 import { ConversationSummary } from "../../reducers/conversations_summary"
 import { RootState } from "../../store"
 import { formatTimeAgo, MIN_SEED_RESPONSES } from "../../util/misc"
 import { getIconForConversation } from "./conversation_list_item"
+import { Card, Container, Flex, Grid, Separator } from "@radix-ui/themes"
 
 const ConversationsPreview = ({ conversations }: { conversations: ConversationSummary[] }) => {
   const hist = useHistory()
 
   return (
-    <Box sx={{ pt: [3], ml: "26px" }}>
+    <Flex direction="column" gap="3">
       {conversations.length === 0 && (
         <Box sx={{ fontWeight: 500, mt: [3], mb: [3], opacity: 0.5 }}>None found</Box>
       )}
@@ -24,43 +25,44 @@ const ConversationsPreview = ({ conversations }: { conversations: ConversationSu
         const timeAgo = formatTimeAgo(+date)
 
         return (
-          <Flex
-            sx={{
-              bg: "bgWhite",
-              border: "1px solid #e2ddd599",
-              borderRadius: "8px",
-              px: [3],
-              py: "12px",
-              mb: [2],
-              lineHeight: 1.3,
-              cursor: "pointer",
-              "&:hover": {
-                border: "1px solid #e2ddd5",
-              },
-            }}
-            key={c.created}
-            onClick={() => hist.push(`/dashboard/c/${c.conversation_id}`)}
-          >
-            <Box sx={{ pr: "13px", pt: "1px" }}>
-              {c.fip_version?.github_pr?.title ? (
-                getIconForConversation(c)
-              ) : (
-                <BiSolidBarChartAlt2 color="#0090ff" />
-              )}
-            </Box>
-            <Box>
+          <Card key={c.created}>
+            <Flex
+              sx={{
+                bg: "bgWhite",
+                border: "1px solid #e2ddd599",
+                borderRadius: "8px",
+                px: [3],
+                py: "12px",
+                mb: [2],
+                lineHeight: 1.3,
+                cursor: "pointer",
+                "&:hover": {
+                  border: "1px solid #e2ddd5",
+                },
+              }}
+              onClick={() => hist.push(`/dashboard/c/${c.conversation_id}`)}
+            >
+              <Box sx={{ pr: "13px", pt: "1px" }}>
+                {c.fip_version?.github_pr?.title ? (
+                  getIconForConversation(c)
+                ) : (
+                  <BiSolidBarChartAlt2 color="#0090ff" />
+                )}
+              </Box>
               <Box>
-                {c.fip_version?.github_pr?.title && <Text sx={{ fontWeight: 600 }}>FIP: </Text>}
-                {c.fip_version?.fip_title || c.fip_version?.github_pr?.title || c.topic}
+                <Box>
+                  {c.fip_version?.github_pr?.title && <Text sx={{ fontWeight: 600 }}>FIP: </Text>}
+                  {c.fip_version?.fip_title || c.fip_version?.github_pr?.title || c.topic}
+                </Box>
+                <Box sx={{ opacity: 0.6, fontSize: "0.94em", mt: "3px", fontWeight: 400 }}>
+                  Created {timeAgo}
+                </Box>
               </Box>
-              <Box sx={{ opacity: 0.6, fontSize: "0.94em", mt: "3px", fontWeight: 400 }}>
-                Created {timeAgo}
-              </Box>
-            </Box>
-          </Flex>
+            </Flex>
+          </Card>
         )
       })}
-    </Box>
+    </Flex>
   )
 }
 
@@ -69,13 +71,12 @@ export const LandingPage = () => {
   const conversations = data || []
 
   return (
-    <Box sx={{ maxWidth: [null, "540px"], px: [3], py: [3], pt: [8], margin: "0 auto" }}>
-      <Flex sx={{
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-
-      }}>
+    <Container size="3">
+      <Flex
+        direction="column"
+        align="center"
+        justify="center"
+      >
         <Image
           src="/filecoin.png"
           width="80px"
@@ -92,48 +93,61 @@ export const LandingPage = () => {
           A nonbinding sentiment check tool for the Filecoin community.
         </Text>
       </Flex>
-      {/* FIPs */}
-      <Flex sx={{ pt: [3], mt: [3] }}>
-        <Box sx={{ flex: "0 0 25px" }}>
-          <TbGitPullRequest color="#3fba50" style={{ marginRight: "6px" }} />
-        </Box>
-        <Box>
-          <Text sx={{ fontWeight: 700 }}>Signal your position</Text> on FIPs through sentiment
-          checks. <br />
-          The following FIPs are currently open for sentiment checks:
-        </Box>
-      </Flex>
-      <ConversationsPreview
-        conversations={conversations
-          .filter((c) => !c.is_archived && !c.is_hidden && c.fip_version?.github_pr?.title && c.fip_version?.fip_files_created)
-          .slice(0, 5)}
-      />
-      {/* discussions */}
-      <Flex sx={{ pt: [3], mt: [3] }}>
-        <Box sx={{ flex: "0 0 25px" }}>
-          <BiSolidBarChartAlt2 color="#0090ff" style={{ marginRight: "6px" }} />
-        </Box>
-        <Box>
-          <Text sx={{ fontWeight: 700 }}>
-            Initiate discussions, collect feedback, and respond to polls
-          </Text>{" "}
-          on open-ended thoughts or ideas.
-        </Box>
-      </Flex>
-      <Box sx={{ pt: [2], pl: "25px" }}>
-        The following discussion polls have been active recently:
-      </Box>
-      <ConversationsPreview
-        conversations={conversations
-          .filter(
-            (c) =>
-              !c.is_archived &&
-              !c.is_hidden &&
-              !c.fip_version?.github_pr?.title &&
-              c.comment_count >= MIN_SEED_RESPONSES,
-          )
-          .slice(0, 5)}
-      />
-    </Box>
+      <Grid columns="2" gap="4" pt="6">
+        {/* discussions */}
+        <Card>
+          <Flex direction="column" gap="3" mx="2" mt="3">
+            <Flex>
+              <Box sx={{ flex: "0 0 25px" }}>
+                <BiSolidBarChartAlt2 color="#0090ff" style={{ marginRight: "6px" }} />
+              </Box>
+              <Box>
+                <Text sx={{ fontWeight: 700 }}>
+                  Initiate discussions, collect feedback, and respond to polls
+                </Text>{" "}
+                on open-ended thoughts or ideas.
+              </Box>
+            </Flex>
+            <Separator size="4"/>
+
+              The following discussion polls have been active recently:
+
+            <ConversationsPreview
+              conversations={conversations
+                .filter(
+                  (c) =>
+                    !c.is_archived &&
+                    !c.is_hidden &&
+                    !c.fip_version?.github_pr?.title &&
+                    c.comment_count >= MIN_SEED_RESPONSES,
+                )
+                .slice(0, 5)}
+            />
+          </Flex>
+        </Card>
+        {/* FIPs */}
+        <Card>
+          <Flex direction="column" gap="3" mx="2" mt="3">
+            <Flex>
+              <Box sx={{ flex: "0 0 25px" }}>
+                <TbGitPullRequest color="#3fba50" style={{ marginRight: "6px" }} />
+              </Box>
+              <Box>
+                <Text sx={{ fontWeight: 700 }}>Signal your position</Text> on FIPs through sentiment
+                checks. <br />
+
+              </Box>
+            </Flex>
+            <Separator size="4"/>
+            The following FIPs are currently open for sentiment checks:
+            <ConversationsPreview
+              conversations={conversations
+                .filter((c) => !c.is_archived && !c.is_hidden && c.fip_version?.github_pr?.title && c.fip_version?.fip_files_created)
+                .slice(0, 5)}
+            />
+          </Flex>
+        </Card>
+      </Grid>
+    </Container>
   )
 }

--- a/client/src/pages/dashboard/landing_page.tsx
+++ b/client/src/pages/dashboard/landing_page.tsx
@@ -2,7 +2,8 @@ import React from "react"
 
 import { TbGitPullRequest } from "react-icons/tb"
 import { BiSolidBarChartAlt2 } from "react-icons/bi"
-import { useHistory } from "react-router-dom"
+import { Link as RouterLink, useHistory } from "react-router-dom"
+import { Card, Container, Flex, Grid, Link, Separator } from "@radix-ui/themes"
 import { Box, Image, Text } from "theme-ui"
 
 import { useAppSelector } from "../../hooks"
@@ -10,7 +11,6 @@ import { ConversationSummary } from "../../reducers/conversations_summary"
 import { RootState } from "../../store"
 import { formatTimeAgo, MIN_SEED_RESPONSES } from "../../util/misc"
 import { getIconForConversation } from "./conversation_list_item"
-import { Card, Container, Flex, Grid, Separator } from "@radix-ui/themes"
 
 const ConversationsPreview = ({ conversations }: { conversations: ConversationSummary[] }) => {
   const hist = useHistory()
@@ -71,84 +71,94 @@ export const LandingPage = () => {
   const conversations = data || []
 
   return (
-    <Container size="3" mt="8">
-      <Flex
-        direction="column"
-        align="center"
-        justify="center"
-        pt="4"
-      >
-        <Image
-          src="/filecoin.png"
-          width="80px"
-          height="80px"
-          sx={{paddingBottom: 3}}
-        />
-        <Text sx={{
-          fontSize: 4,
-          fontWeight: "bold",
-          paddingBottom: 3,
+    <Box>
+      <Container size="3" mt="4">
+        <Flex
+          direction="column"
+          align="center"
+          justify="center"
+          pt="8"
+        >
+          <Image
+            src="/filecoin.png"
+            width="80px"
+            height="80px"
+            sx={{paddingBottom: 3}}
+          />
+          <Text sx={{
+            fontSize: 4,
+            fontWeight: "bold",
+            paddingBottom: 3,
 
-        }}>Welcome to Fil Poll</Text>
-        <Text sx={{ }}>
-          A nonbinding sentiment check tool for the Filecoin community.
-        </Text>
+          }}>Welcome to Fil Poll</Text>
+          <Text sx={{ }}>
+            A nonbinding sentiment check tool for the Filecoin community.
+          </Text>
+        </Flex>
+        <Grid columns="2" gap="4" py="6">
+          {/* discussions */}
+          <Card>
+            <Flex direction="column" gap="3" mx="2" mt="3">
+              <Flex>
+                <Box sx={{ flex: "0 0 25px" }}>
+                  <BiSolidBarChartAlt2 color="#0090ff" style={{ marginRight: "6px" }} />
+                </Box>
+                <Box>
+                  <Text sx={{ fontWeight: 700 }}>
+                    Initiate discussions, collect feedback, and respond to polls
+                  </Text>{" "}
+                  on open-ended thoughts or ideas.
+                </Box>
+              </Flex>
+              <Separator size="4"/>
+
+                The following discussion polls have been active recently:
+
+              <ConversationsPreview
+                conversations={conversations
+                  .filter(
+                    (c) =>
+                      !c.is_archived &&
+                      !c.is_hidden &&
+                      !c.fip_version?.github_pr?.title &&
+                      c.comment_count >= MIN_SEED_RESPONSES,
+                  )
+                  .slice(0, 5)}
+              />
+            </Flex>
+          </Card>
+          {/* FIPs */}
+          <Card>
+            <Flex direction="column" gap="3" mx="2" mt="3">
+              <Flex>
+                <Box sx={{ flex: "0 0 25px" }}>
+                  <TbGitPullRequest color="#3fba50" style={{ marginRight: "6px" }} />
+                </Box>
+                <Box>
+                  <Text sx={{ fontWeight: 700 }}>Signal your position</Text> on FIPs through sentiment
+                  checks. <br />
+
+                </Box>
+              </Flex>
+              <Separator size="4"/>
+              The following FIPs are currently open for sentiment checks:
+              <ConversationsPreview
+                conversations={conversations
+                  .filter((c) => !c.is_archived && !c.is_hidden && c.fip_version?.github_pr?.title && c.fip_version?.fip_files_created)
+                  .slice(0, 5)}
+              />
+            </Flex>
+          </Card>
+        </Grid>
+      </Container>
+      {/* footer */}
+      <Flex p="4" direction="row">
+        <RouterLink to="/about">
+          <Link weight="bold">About Fil Poll</Link>
+        </RouterLink>
+        <Box sx={{ flex: "1 1 auto" }} />
+        Fil Poll &copy; 2024
       </Flex>
-      <Grid columns="2" gap="4" pt="6">
-        {/* discussions */}
-        <Card>
-          <Flex direction="column" gap="3" mx="2" mt="3">
-            <Flex>
-              <Box sx={{ flex: "0 0 25px" }}>
-                <BiSolidBarChartAlt2 color="#0090ff" style={{ marginRight: "6px" }} />
-              </Box>
-              <Box>
-                <Text sx={{ fontWeight: 700 }}>
-                  Initiate discussions, collect feedback, and respond to polls
-                </Text>{" "}
-                on open-ended thoughts or ideas.
-              </Box>
-            </Flex>
-            <Separator size="4"/>
-
-              The following discussion polls have been active recently:
-
-            <ConversationsPreview
-              conversations={conversations
-                .filter(
-                  (c) =>
-                    !c.is_archived &&
-                    !c.is_hidden &&
-                    !c.fip_version?.github_pr?.title &&
-                    c.comment_count >= MIN_SEED_RESPONSES,
-                )
-                .slice(0, 5)}
-            />
-          </Flex>
-        </Card>
-        {/* FIPs */}
-        <Card>
-          <Flex direction="column" gap="3" mx="2" mt="3">
-            <Flex>
-              <Box sx={{ flex: "0 0 25px" }}>
-                <TbGitPullRequest color="#3fba50" style={{ marginRight: "6px" }} />
-              </Box>
-              <Box>
-                <Text sx={{ fontWeight: 700 }}>Signal your position</Text> on FIPs through sentiment
-                checks. <br />
-
-              </Box>
-            </Flex>
-            <Separator size="4"/>
-            The following FIPs are currently open for sentiment checks:
-            <ConversationsPreview
-              conversations={conversations
-                .filter((c) => !c.is_archived && !c.is_hidden && c.fip_version?.github_pr?.title && c.fip_version?.fip_files_created)
-                .slice(0, 5)}
-            />
-          </Flex>
-        </Card>
-      </Grid>
-    </Container>
+    </Box>
   )
 }

--- a/client/src/pages/dashboard/landing_page.tsx
+++ b/client/src/pages/dashboard/landing_page.tsx
@@ -71,11 +71,12 @@ export const LandingPage = () => {
   const conversations = data || []
 
   return (
-    <Container size="3">
+    <Container size="3" mt="8">
       <Flex
         direction="column"
         align="center"
         justify="center"
+        pt="4"
       >
         <Image
           src="/filecoin.png"

--- a/client/src/pages/dashboard/landing_page.tsx
+++ b/client/src/pages/dashboard/landing_page.tsx
@@ -29,13 +29,15 @@ const ConversationsPreview = ({ conversations }: { conversations: ConversationSu
             key={c.created}
             onClick={() => hist.push(`/dashboard/c/${c.conversation_id}`)}
           >
-            <Flex>
-              <Box pr="13px" pt="1px">
-                {fipVersion?.github_pr?.title ? (
-                  getIconForConversation(c)
-                ) : (
-                  <BiSolidBarChartAlt2 color="#0090ff" />
-                )}
+            <Flex gap="3">
+              <Box>
+                <Text size="2">
+                  {fipVersion?.github_pr?.title ? (
+                    getIconForConversation(c)
+                  ) : (
+                    <BiSolidBarChartAlt2 color="#0090ff" />
+                  )}
+                </Text>
               </Box>
               <Box>
                 <Box>
@@ -87,9 +89,13 @@ export const LandingPage = () => {
         <Grid columns="2" gap="4" py="6">
           {/* discussions */}
           <Card>
-            <Flex direction="column" gap="3" mx="2" mt="3">
-              <Flex>
-                <BiSolidBarChartAlt2 color="#0090ff" style={{ marginRight: "6px" }} />
+            <Flex direction="column" gap="4" mx="2" mt="3">
+              <Flex gap="3">
+                <Box>
+                  <Text size="2">
+                    <BiSolidBarChartAlt2 color="#0090ff" />
+                  </Text>
+                </Box>
                 <Box>
                   <Text weight="bold">
                     Initiate discussions, collect feedback, and respond to polls
@@ -116,9 +122,13 @@ export const LandingPage = () => {
           </Card>
           {/* FIPs */}
           <Card>
-            <Flex direction="column" gap="3" mx="2" mt="3">
-              <Flex>
-                <TbGitPullRequest color="#3fba50" style={{ marginRight: "6px" }} />
+            <Flex direction="column" gap="4" mx="2" mt="3">
+              <Flex gap="3">
+                <Box>
+                  <Text size="2">
+                    <TbGitPullRequest color="#3fba50" />
+                  </Text>
+                </Box>
                 <Box>
                   <Text weight="bold">Signal your position</Text> on FIPs through sentiment
                   checks. <br />

--- a/client/src/pages/dashboard/landing_page.tsx
+++ b/client/src/pages/dashboard/landing_page.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import { TbGitPullRequest } from "react-icons/tb"
 import { BiSolidBarChartAlt2 } from "react-icons/bi"
 import { useHistory } from "react-router-dom"
-import { Box, Flex, Text } from "theme-ui"
+import { Box, Flex, Image, Text } from "theme-ui"
 
 import { useAppSelector } from "../../hooks"
 import { ConversationSummary } from "../../reducers/conversations_summary"
@@ -70,10 +70,28 @@ export const LandingPage = () => {
 
   return (
     <Box sx={{ maxWidth: [null, "540px"], px: [3], py: [3], pt: [8], margin: "0 auto" }}>
-      <Box>
-        Welcome to Fil Poll, a nonbinding sentiment check tool for the Filecoin community. You
-        can:
-      </Box>
+      <Flex sx={{
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+
+      }}>
+        <Image
+          src="/filecoin.png"
+          width="80px"
+          height="80px"
+          sx={{paddingBottom: 3}}
+        />
+        <Text sx={{
+          fontSize: 4,
+          fontWeight: "bold",
+          paddingBottom: 3,
+
+        }}>Welcome to Fil Poll</Text>
+        <Text sx={{ }}>
+          A nonbinding sentiment check tool for the Filecoin community.
+        </Text>
+      </Flex>
       {/* FIPs */}
       <Flex sx={{ pt: [3], mt: [3] }}>
         <Box sx={{ flex: "0 0 25px" }}>

--- a/client/src/pages/dashboard/user_button.tsx
+++ b/client/src/pages/dashboard/user_button.tsx
@@ -1,9 +1,20 @@
 import React from "react"
-import { Text, Button } from "theme-ui"
 
 import { useAppSelector } from "../../hooks"
 import { RootState } from "../../store"
 import { useHistory } from "react-router-dom"
+import { Box, Button, Text } from "@radix-ui/themes"
+
+export const TopRightFloating = ({children}: {children: React.ReactNode}) => {
+  return <Box
+    position="absolute"
+    top="3"
+    right="3"
+    >
+    {children}
+  </Box>
+}
+
 
 export const DashboardUserButton = () => {
   const { loading, user, isLoggedIn } = useAppSelector((state: RootState) => state.user)
@@ -13,23 +24,28 @@ export const DashboardUserButton = () => {
     return null
   }
 
-  if (isLoggedIn) {
-    return (
-      <Button
-        variant="outlineSecondary"
-        sx={{
-          position: "absolute",
-          top: ["10px", "12px"],
-          right: ["14px", "18px"],
-          alignItems: "center",
-          zIndex: 1,
-        }}
-        onClick={() => hist.push(`/account`)}
-      >
-        <Text sx={{ display: "inline-block" }}>
-          {user.email || user.githubUsername || "View Account"}
-        </Text>
-      </Button>
-    )
-  }
+    return <TopRightFloating>
+      {
+        isLoggedIn
+        ? <Button
+            color="gold"
+            variant="surface"
+            onClick={() => hist.push(`/account`)}
+          >
+            <Text sx={{ display: "inline-block" }}>
+              {user.email || user.githubUsername || "View Account"}
+            </Text>
+          </Button>
+        : <Button
+            // TODO: what is the idiomatic radix UI way to make this black?
+            color="gray"
+            variant="solid"
+            onClick={() => {
+                document.location = `/api/v3/github_oauth_init?dest=${window.location.href}`
+            }}
+          >
+            Sign in with Github
+          </Button>
+      }
+    </TopRightFloating>
 }

--- a/client/src/pages/dashboard/user_button.tsx
+++ b/client/src/pages/dashboard/user_button.tsx
@@ -15,7 +15,6 @@ export const TopRightFloating = ({children}: {children: React.ReactNode}) => {
   </Box>
 }
 
-
 export const DashboardUserButton = () => {
   const { loading, user, isLoggedIn } = useAppSelector((state: RootState) => state.user)
   const hist = useHistory()
@@ -30,6 +29,7 @@ export const DashboardUserButton = () => {
         ? <Button
             color="gold"
             variant="surface"
+            radius="large"
             onClick={() => hist.push(`/account`)}
           >
             <Text sx={{ display: "inline-block" }}>
@@ -37,11 +37,12 @@ export const DashboardUserButton = () => {
             </Text>
           </Button>
         : <Button
-            // TODO: what is the idiomatic radix UI way to make this black?
             color="gray"
             variant="solid"
+            radius="large"
+            highContrast
             onClick={() => {
-                document.location = `/api/v3/github_oauth_init?dest=${window.location.href}`
+              document.location = `/api/v3/github_oauth_init?dest=${window.location.href}`
             }}
           >
             Sign in with Github


### PR DESCRIPTION
Issue: https://github.com/canvasxyz/metropolis/issues/62

This PR makes a number of stylistic/layout changes to the landing page

- [x] rename "Placeholder" -> "LandingPage"
- [x] move "sign in with github" button to top right, floating
- [x] put "Signal your position" and "Initiate discussions..." sections alongside each other
- [x] put them in cards with rounded corners
- [x] put fil poll logo in the middle
- [x] Update "A nonbinding sentiment check tool for the Filecoin community" copy
- [x] "About Metropolis" in the bottom left
- [x] Copyright in bottom right
- [x] Move components over to Radix
- [x] Make spacings and dimensions fit the design
- [x] Cards should have more rounded corners
- [ ] Update text/link colors - I want to do this in a separate PR, since it would be best to configure this globally as a default

![Screenshot 2024-12-05 at 7 46 47 AM](https://github.com/user-attachments/assets/603e43f8-b312-416d-9d18-709eae0d2959)
![Screenshot 2024-12-05 at 7 46 53 AM](https://github.com/user-attachments/assets/0330f58e-057f-49c7-94ae-402f4f8418aa)
