### PR TITLE
Add "permalink" button to FIP Tracker and Sentiment Checks

### DIFF
--- a/client/src/pages/dashboard/conversation.tsx
+++ b/client/src/pages/dashboard/conversation.tsx
@@ -167,13 +167,16 @@ export const DashboardConversation = ({ user }: { user }) => {
             </Box>
           ) : (
             zid_metadata.description && (
-              <Box pt="18px">
-                <Collapsible
-                  title={displayTitle}
-                  key={zid_metadata.conversation_id}
-                  shouldCollapse={false}
-                  content={zid_metadata.description}
-                ></Collapsible>
+              <Box
+                py="10px"
+                px="16px"
+                my="3"
+                style={{
+                  backgroundColor: "white",
+                  lineHeight: 1.35,
+                  border: "1px solid #ddd"
+                }}>
+                  {zid_metadata.description}
               </Box>
             )
           )}

--- a/client/src/pages/dashboard/fip_tracker/fip_entry.tsx
+++ b/client/src/pages/dashboard/fip_tracker/fip_entry.tsx
@@ -1,5 +1,5 @@
 import dayjs from "dayjs"
-import React, { useState } from "react"
+import React, { MutableRefObject, Ref, RefObject, useEffect, useRef, useState } from "react"
 import { TbArrowUpRight, TbCalendar, TbChevronDown, TbChevronRight } from "react-icons/tb"
 import { Link } from "react-router-dom-v5-compat"
 
@@ -8,6 +8,7 @@ import { statusOptions } from "./status_options"
 import { FipVersion } from "../../../util/types"
 import { UserInfo } from "./splitAuthors"
 import SimpleSummary from "./simple_summary"
+import { BiLink } from "react-icons/bi"
 
 const FIP_REPO_OWNER = process.env.FIP_REPO_OWNER || "filecoin-project"
 const FIP_REPO_NAME = process.env.FIP_REPO_NAME || "FIPs"
@@ -67,12 +68,14 @@ const FipEntryInner = ({
 }
 
 export const FipEntry = ({
+  scrollOnLoad,
   conversation,
   showAuthors,
   showCategory,
   showCreationDate,
   showType,
 }: {
+  scrollOnLoad: boolean
   conversation: FipVersion & {
     displayed_title: string
     fip_authors: UserInfo[]
@@ -82,7 +85,15 @@ export const FipEntry = ({
   showCreationDate: boolean
   showType: boolean
 }) => {
+  const ref = useRef<HTMLDivElement>(null)
   const [isOpen, setIsOpen] = useState(false)
+
+  useEffect(() => {
+    if (scrollOnLoad && ref.current) {
+      ref.current.scrollIntoView()
+      setIsOpen(true)
+    }
+  }, [])
 
   let fipStatusKey = conversation.fip_status.toLowerCase().replace(" ", "-")
   if (fipStatusKey === "wip") {
@@ -157,6 +168,7 @@ export const FipEntry = ({
 
   return (
     <div
+      ref={ref}
       style={{
         borderRadius: "8px",
         borderStyle: "solid",
@@ -248,6 +260,24 @@ export const FipEntry = ({
               PR <TbArrowUpRight style={{ position: "relative", top: "2px" }} />
             </Link>
           )}
+          <Link
+              className="link"
+              to={`/dashboard/fip_tracker?view=${conversation.id}`}
+              target="_blank"
+              noreferrer="noreferrer"
+              noopener="noopener"
+              onClick={(e) => e.stopPropagation()}
+              style={{
+                display: "block",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                fontSize: "90%",
+                fontWeight: "500",
+              }}
+            >
+            <BiLink style={{top: "0px"}}/>
+          </Link>
         </Flex>
         <Box></Box>
         <Flex

--- a/client/src/pages/dashboard/fip_tracker/index.tsx
+++ b/client/src/pages/dashboard/fip_tracker/index.tsx
@@ -123,6 +123,7 @@ const FipTracker = () => {
 
   const [searchParams, setSearchParams] = useSearchParams()
 
+  const viewParam = searchParams.get("view") || ""
   const searchParam = searchParams.get("search") || ""
 
   const { data } = useSWR(
@@ -470,6 +471,7 @@ const FipTracker = () => {
       <Flex direction="column" gap="12px">
         {displayedFips.map((conversation) => (
           <FipEntry
+            scrollOnLoad={viewParam === conversation.id.toString()}
             key={conversation.id}
             conversation={conversation}
             showAuthors={showAuthors}

--- a/client/src/pages/dashboard/sentiment_checks/conversation_entry.tsx
+++ b/client/src/pages/dashboard/sentiment_checks/conversation_entry.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
 import { TbCalendar, TbCaretDown, TbCaretRight } from "react-icons/tb"
 
 import { Badge, Box, Flex, Grid, Text } from "@radix-ui/themes"
@@ -7,17 +7,30 @@ import ReportAndSurveyInfo from "../report_and_survey_info"
 import { SentimentCheckComments } from "../sentiment_check_comments"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
+import { Link } from "react-router-dom-v5-compat"
+import { BiLink } from "react-icons/bi"
 
 export const ConversationEntry = ({
+  scrollOnLoad,
   conversation,
   showCreationDate,
 }: {
+  scrollOnLoad: boolean
   conversation: ConversationSummary & {
     displayed_title: string
   }
   showCreationDate: boolean
 }) => {
   const [isOpen, setIsOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (scrollOnLoad && ref.current) {
+      ref.current.scrollIntoView()
+      setIsOpen(true)
+    }
+  }, [])
+
   const fipAttributes = []
   if (showCreationDate) {
     fipAttributes.push(
@@ -77,6 +90,24 @@ export const ConversationEntry = ({
           <Badge size="2" color={color} variant="surface" radius="full">
             {statusLabel}
           </Badge>
+          <Link
+              className="link"
+              to={`/dashboard/sentiment_checks?view=${conversation.conversation_id}`}
+              target="_blank"
+              noreferrer="noreferrer"
+              noopener="noopener"
+              onClick={(e) => e.stopPropagation()}
+              style={{
+                display: "block",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                fontSize: "90%",
+                fontWeight: "500",
+              }}
+            >
+            <BiLink style={{top: "0px"}}/>
+          </Link>
         </Flex>
         <Box></Box>
         <Flex

--- a/client/src/pages/dashboard/sentiment_checks/index.tsx
+++ b/client/src/pages/dashboard/sentiment_checks/index.tsx
@@ -51,6 +51,7 @@ export default () => {
 
   const [searchParams, setSearchParams] = useSearchParams()
 
+  const viewParam = searchParams.get("view") || ""
   const searchParam = searchParams.get("search") || ""
 
   const { data } = useSWR(
@@ -255,6 +256,7 @@ export default () => {
         <Flex direction="column" gap="3">
           {displayedConversations.map((conversation) => (
             <ConversationEntry
+              scrollOnLoad={viewParam === conversation.conversation_id}
               key={conversation.conversation_id}
               conversation={conversation}
               showCreationDate={showCreationDate}


### PR DESCRIPTION
https://github.com/canvasxyz/metropolis/issues/64

This PR adds a "permalink" button to the FIP Tracker and Sentiment Checks pages. This lets the user create a link to a particular FIP/Sentiment Check, when this link is loaded, the page automatically scrolls to the referenced item.

![Screenshot 2024-12-16 at 4 46 35 PM](https://github.com/user-attachments/assets/22cc2d9e-4949-4b0b-bec2-60bb3e1a2bdd)

There's definitely more we could do in terms of persisting the views here, e.g. encoding the filters in the URL, but I thought this was a good place to start.