### PR TITLE
Implement Metropolis feedback

### DIFF
--- a/client/src/components/ClickableChecklistItem.tsx
+++ b/client/src/components/ClickableChecklistItem.tsx
@@ -1,4 +1,4 @@
-import { Link, Box, Button, Checkbox, DropdownMenu, Flex } from "@radix-ui/themes"
+import { Link, Box, Checkbox, DropdownMenu, Flex } from "@radix-ui/themes"
 import React, { ReactNode, useRef } from "react"
 
 export const ClickableChecklistItem = ({

--- a/client/src/pages/CreateConversationModal.tsx
+++ b/client/src/pages/CreateConversationModal.tsx
@@ -25,7 +25,7 @@ const CreateConversationInner = () => {
     <Box>
       <Flex>
         <Heading as="h2" sx={{ flex: 1, position: "relative", top: "4px" }}>
-          Create a sentiment check
+          Create a discussion poll
         </Heading>
       </Flex>
 

--- a/client/src/pages/admin/conversation-config.tsx
+++ b/client/src/pages/admin/conversation-config.tsx
@@ -11,9 +11,7 @@ import { CheckboxField } from "./CheckboxField"
 import api from "../../util/api"
 import { RootState } from "../../store"
 import { useAppDispatch, useAppSelector } from "../../hooks"
-
-const FIP_REPO_OWNER = process.env.FIP_REPO_OWNER
-const FIP_REPO_NAME = process.env.FIP_REPO_NAME
+import { getGitHubPrUrl } from "../../util/github_pr"
 
 const Input = (props: ComponentProps<"input">) => (
   <input
@@ -202,7 +200,7 @@ const ConversationConfig = ({ error }: ConversationConfigProps) => {
                 <Box sx={{ mb: [3] }}>
                   PR{" "}
                   <a
-                    href={`https://github.com/${FIP_REPO_OWNER}/${FIP_REPO_NAME}/pull/${zid_metadata.fip_version.github_pr.id}`}
+                    href={getGitHubPrUrl(zid_metadata.fip_version.github_pr)}
                   >
                     #{zid_metadata.fip_version.github_pr.id}
                   </a>

--- a/client/src/pages/dashboard/conversation.tsx
+++ b/client/src/pages/dashboard/conversation.tsx
@@ -12,8 +12,8 @@ import { RootState } from "../../store"
 import { useAppSelector, useAppDispatch } from "../../hooks"
 import { surveyBox } from "../survey"
 import { populateZidMetadataStore } from "../../actions"
-import { SentimentCheck } from "./sentiment_check"
-import { SentimentCheckComments } from "./sentiment_check_comments"
+import { DiscussionPoll } from "./discussion_poll"
+import { DiscussionPollComments } from "./discussion_poll_comments"
 import { Frontmatter, Collapsible } from "./front_matter"
 import { incrementViewCount, useViewCount } from "../../reducers/view_counts"
 import { MIN_SEED_RESPONSES } from "../../util/misc"
@@ -28,7 +28,7 @@ const dashboardBox = {
   border: "1px solid #ddd",
 }
 
-const SentimentTooltip = () => {
+const DiscussionPollTooltip = () => {
   const [referenceElement, setReferenceElement] = useState(null)
   const [popperElement, setPopperElement] = useState(null)
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
@@ -194,10 +194,10 @@ export const DashboardConversation = ({ user }: { user }) => {
                   mb: [2],
                 }}
               >
-                Sentiment Check
-                <SentimentTooltip />
+                Discussion Poll
+                <DiscussionPollTooltip />
               </Box>
-              <SentimentCheck
+              <DiscussionPoll
                 user={user}
                 zid_metadata={zid_metadata}
                 key={zid_metadata.conversation_id}
@@ -232,7 +232,7 @@ export const DashboardConversation = ({ user }: { user }) => {
                 Have more to say? You can leave a short comment here.
                 </Box> */}
               <Box sx={{ mx: "-8px", pt: "8px" }}>
-                <SentimentCheckComments conversationId={zid_metadata.conversation_id} />
+                <DiscussionPollComments conversationId={zid_metadata.conversation_id} />
               </Box>
             </Box>
           )}

--- a/client/src/pages/dashboard/conversations_list.tsx
+++ b/client/src/pages/dashboard/conversations_list.tsx
@@ -43,7 +43,7 @@ const ConversationsList = ({
 
   return (
     <React.Fragment>
-      <Flex justify="center" pt="0px" pb="8px" mx="16px">
+      <Flex justify="center" pt="8px" pb="6px" mx="16px">
         <Button
           className="left-group-button"
           variant="outline"

--- a/client/src/pages/dashboard/conversations_list.tsx
+++ b/client/src/pages/dashboard/conversations_list.tsx
@@ -1,14 +1,10 @@
 import useSWR from "swr"
-import React, { useState, useEffect } from "react"
-import { useLocalStorage } from "usehooks-ts"
-import { Button, Box, Link } from "theme-ui"
-import { TbExternalLink, TbFocus } from "react-icons/tb"
-import { BiSolidBarChartAlt2 } from "react-icons/bi"
+import React from "react"
 
 import { MIN_SEED_RESPONSES } from "../../util/misc"
 import ConversationListItem from "./conversation_list_item"
 import { ConversationSummary } from "../../reducers/conversations_summary"
-import { Badge, Box, Button, Flex } from "@radix-ui/themes"
+import { Badge, Button, Flex } from "@radix-ui/themes"
 
 const ConversationsList = ({
   selectedView,

--- a/client/src/pages/dashboard/discussion_poll.tsx
+++ b/client/src/pages/dashboard/discussion_poll.tsx
@@ -16,7 +16,7 @@ import { ZidMetadata } from "../../util/types"
 const LIKE_VOTE = "like"
 const DISLIKE_VOTE = "dislike"
 
-export const SentimentCheck = ({
+export const DiscussionPoll = ({
   user,
   zid_metadata,
 }: {

--- a/client/src/pages/dashboard/discussion_poll_comments.tsx
+++ b/client/src/pages/dashboard/discussion_poll_comments.tsx
@@ -8,7 +8,7 @@ const MAX_COMMENT_LENGTH = 150
 
 const fetcher = (url) => fetch(url).then((r) => r.json())
 
-export const SentimentCheckComments= ({
+export const DiscussionPollComments= ({
   conversationId,
 }: { conversationId: string }) => {
   const { user } = useAppSelector((state) => state.user)

--- a/client/src/pages/dashboard/discussion_polls/conversation_entry.tsx
+++ b/client/src/pages/dashboard/discussion_polls/conversation_entry.tsx
@@ -4,6 +4,7 @@ import { Box, Flex, Grid } from "theme-ui"
 
 import { Badge, Text } from "@radix-ui/themes"
 import { ConversationSummary } from "../../../reducers/conversations_summary"
+import { useNavigate } from "react-router-dom-v5-compat"
 
 export const ConversationEntry = ({
   conversation,
@@ -14,6 +15,7 @@ export const ConversationEntry = ({
   }
   showCreationDate: boolean
 }) => {
+  const navigate = useNavigate()
 
   const fipBadges = []
   const fipAttributes = []
@@ -42,6 +44,7 @@ export const ConversationEntry = ({
         padding: "3px 0 6px",
         background: "#fff",
       }}
+      onClick={() => navigate(`/dashboard/c/${conversation.conversation_id}`)}
     >
       <Grid
         sx={{

--- a/client/src/pages/dashboard/discussion_polls/conversation_entry.tsx
+++ b/client/src/pages/dashboard/discussion_polls/conversation_entry.tsx
@@ -1,22 +1,9 @@
-import React, { useState } from "react"
-import { TbCalendar, TbCaretDown, TbCaretRight } from "react-icons/tb"
+import React from "react"
+import { TbCalendar } from "react-icons/tb"
 import { Box, Flex, Grid } from "theme-ui"
 
 import { Badge, Text } from "@radix-ui/themes"
 import { ConversationSummary } from "../../../reducers/conversations_summary"
-import ReportAndSurveyInfo from "../report_and_survey_info"
-import { DiscussionPollComments } from "../discussion_poll_comments"
-import ReactMarkdown from "react-markdown"
-import remarkGfm from "remark-gfm"
-
-const dashboardBox = {
-  bg: "bgWhite",
-  py: "18px",
-  px: "22px",
-  // my: [3],
-  lineHeight: 1.35,
-  border: "1px solid #ddd",
-}
 
 export const ConversationEntry = ({
   conversation,
@@ -27,7 +14,6 @@ export const ConversationEntry = ({
   }
   showCreationDate: boolean
 }) => {
-  const [isOpen, setIsOpen] = useState(false)
 
   const fipBadges = []
   const fipAttributes = []
@@ -56,7 +42,6 @@ export const ConversationEntry = ({
         padding: "3px 0 6px",
         background: "#fff",
       }}
-      onClick={() => setIsOpen(!isOpen)}
     >
       <Grid
         sx={{
@@ -67,9 +52,8 @@ export const ConversationEntry = ({
           gridRowGap: "10px",
         }}
       >
-        <Flex sx={{ flexDirection: "row", gap: [4], alignItems: "center" }}>
-          {isOpen ? <TbCaretDown /> : <TbCaretRight />}
-        </Flex>
+        {/* grid spacer for first column */}
+        <Box/>
         <Flex sx={{ flexDirection: "row", gap: [3], alignItems: "center" }}>
           <Text style={{ flex: 1, lineHeight: 1.3, fontSize: "95%", fontWeight: 500 }}>
             {conversation.displayed_title || <Text sx={{ color: "#84817D" }}>Untitled</Text>}
@@ -101,33 +85,6 @@ export const ConversationEntry = ({
           ))}
           <Box sx={{ flexGrow: "1" }}></Box>
         </Flex>
-        { isOpen &&
-          <>
-            <Box></Box>
-            <Box>
-              <ReactMarkdown
-                skipHtml={true}
-                remarkPlugins={[remarkGfm]}
-                linkTarget="_blank"
-                className="react-markdown"
-              >
-                {conversation.description}
-              </ReactMarkdown>
-            </Box>
-            <Box></Box>
-            <ReportAndSurveyInfo conversation_info={conversation}/>
-            <Box></Box>
-            <Box sx={dashboardBox}>
-              <Box sx={{ fontWeight: "bold", pb: [1] }}>Comments</Box>
-              {/* <Box sx={{ color: "mediumGray", pb: [1] }}>
-                Have more to say? You can leave a short comment here.
-                </Box> */}
-              <Box sx={{ mx: "-8px", pt: "8px" }}>
-                <DiscussionPollComments conversationId={conversation.conversation_id} />
-              </Box>
-            </Box>
-          </>
-        }
       </Grid>
     </div>
   )

--- a/client/src/pages/dashboard/discussion_polls/conversation_entry.tsx
+++ b/client/src/pages/dashboard/discussion_polls/conversation_entry.tsx
@@ -5,7 +5,7 @@ import { Box, Flex, Grid } from "theme-ui"
 import { Badge, Text } from "@radix-ui/themes"
 import { ConversationSummary } from "../../../reducers/conversations_summary"
 import ReportAndSurveyInfo from "../report_and_survey_info"
-import { SentimentCheckComments } from "../sentiment_check_comments"
+import { DiscussionPollComments } from "../discussion_poll_comments"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 
@@ -123,7 +123,7 @@ export const ConversationEntry = ({
                 Have more to say? You can leave a short comment here.
                 </Box> */}
               <Box sx={{ mx: "-8px", pt: "8px" }}>
-                <SentimentCheckComments conversationId={conversation.conversation_id} />
+                <DiscussionPollComments conversationId={conversation.conversation_id} />
               </Box>
             </Box>
           </>

--- a/client/src/pages/dashboard/discussion_polls/index.tsx
+++ b/client/src/pages/dashboard/discussion_polls/index.tsx
@@ -20,6 +20,7 @@ import { ConversationSummary } from "../../../reducers/conversations_summary"
 import { ConversationEntry } from "./conversation_entry"
 import { useAppSelector } from "../../../hooks"
 import { CreateConversationModal } from "../../CreateConversationModal"
+import { useDiscussionPollDisplayOptions } from "./useDiscussionPollDisplayOptions"
 
 const conversationStatusOptions = {
   open: { label: "Open", color: "blue" },
@@ -43,19 +44,11 @@ export default () => {
   const [createConversationModalIsOpen, setCreateConversationModalIsOpen] = useState(false)
 
   const {
-    showAuthors,
-    setShowAuthors,
-    showCategory,
-    setShowCategory,
-    showCreationDate,
-    setShowCreationDate,
-    showType,
-    setShowType,
     sortBy,
     setSortBy,
     resetDisplayOptions,
     saveDisplayOptions,
-  } = useFipDisplayOptions()
+  } = useDiscussionPollDisplayOptions()
 
   const [searchParams, setSearchParams] = useSearchParams()
 
@@ -235,21 +228,6 @@ export default () => {
                   </Select.Content>
                 </Select.Root>
               </DropdownMenu.Label>
-              <DropdownMenu.Separator />
-              <DropdownMenu.Label>Show / Hide</DropdownMenu.Label>
-              <ClickableChecklistItem checked={showType} setChecked={setShowType}>
-                Type
-              </ClickableChecklistItem>
-              <ClickableChecklistItem checked={showCategory} setChecked={setShowCategory}>
-                Category
-              </ClickableChecklistItem>
-              <ClickableChecklistItem checked={showCreationDate} setChecked={setShowCreationDate}>
-                Creation Date
-              </ClickableChecklistItem>
-              <ClickableChecklistItem checked={showAuthors} setChecked={setShowAuthors}>
-                Authors
-              </ClickableChecklistItem>
-              <DropdownMenu.Separator />
               <DropdownMenu.Label
                 onClick={(e) => {
                   e.preventDefault()
@@ -271,7 +249,7 @@ export default () => {
             <ConversationEntry
               key={conversation.conversation_id}
               conversation={conversation}
-              showCreationDate={showCreationDate}
+              showCreationDate={true}
             />
           ))}
         </Flex>

--- a/client/src/pages/dashboard/discussion_polls/index.tsx
+++ b/client/src/pages/dashboard/discussion_polls/index.tsx
@@ -92,7 +92,7 @@ export default () => {
       // the conversation's displayed title must include the search string, if it is given
       if (
         searchParam &&
-        !conversation.displayed_title.toLowerCase().includes(searchParam.toLowerCase())
+        !(conversation.displayed_title || "").toLowerCase().includes(searchParam.toLowerCase())
       ) {
         return false
       }

--- a/client/src/pages/dashboard/discussion_polls/index.tsx
+++ b/client/src/pages/dashboard/discussion_polls/index.tsx
@@ -62,7 +62,7 @@ export default () => {
   const searchParam = searchParams.get("search") || ""
 
   const { data } = useSWR(
-    `conversations_summary_sentiment_checks`,
+    `conversations_summary_discussion_polls`,
     async () => {
       const response = await fetch(`/api/v3/conversations_summary`)
       // process the fip_version part if it exists
@@ -139,7 +139,7 @@ export default () => {
           gap: [3],
         }}
       >
-        <Text sx={{ fontWeight: 600, fontSize: [2] }}>Sentiment Checks</Text>
+        <Text sx={{ fontWeight: 600, fontSize: [2] }}>Discussion Polls</Text>
         <Flex sx={{ gap: [2], width: "100%" }}>
           <Box flexGrow="1" maxWidth="400px">
             <TextField.Root

--- a/client/src/pages/dashboard/discussion_polls/useDiscussionPollDisplayOptions.ts
+++ b/client/src/pages/dashboard/discussion_polls/useDiscussionPollDisplayOptions.ts
@@ -1,0 +1,34 @@
+import { useState } from "react"
+import { toast } from "react-hot-toast"
+import { useLocalStorage } from "usehooks-ts"
+
+export const useDiscussionPollDisplayOptions = () => {
+  const [savedDisplayOptions, setSavedDisplayOptions] = useLocalStorage(
+    "discussionPollDisplayOptions",
+    JSON.stringify({
+      sortBy: "desc"
+    }),
+  )
+  const initialSavedDisplayOptions = JSON.parse(savedDisplayOptions)
+
+  const [sortBy, setSortBy] = useState<"desc" | "asc">(initialSavedDisplayOptions.sortBy)
+
+  const resetDisplayOptions = () => {
+    toast.success("Reset saved display options for Discussion Polls")
+    setSortBy(initialSavedDisplayOptions.sortBy)
+  }
+
+  const saveDisplayOptions = () => {
+    toast.success("Saved display options for Discussion Polls")
+    setSavedDisplayOptions(
+      JSON.stringify({  sortBy }),
+    )
+  }
+
+  return {
+    sortBy,
+    setSortBy,
+    resetDisplayOptions,
+    saveDisplayOptions,
+  }
+}

--- a/client/src/pages/dashboard/fip_tracker/fip_entry.tsx
+++ b/client/src/pages/dashboard/fip_tracker/fip_entry.tsx
@@ -9,6 +9,7 @@ import { statusOptions } from "./status_options"
 import { FipVersion } from "../../../util/types"
 import { UserInfo } from "./splitAuthors"
 import SimpleSummary from "./simple_summary"
+import { getGitHubPrUrl } from "../../../util/github_pr"
 
 const FIP_REPO_OWNER = process.env.FIP_REPO_OWNER || "filecoin-project"
 const FIP_REPO_NAME = process.env.FIP_REPO_NAME || "FIPs"
@@ -227,7 +228,7 @@ export const FipEntry = ({
           {conversation.github_pr && (
             <Link
               className="link"
-              to={conversation.github_pr.url.replace(/\/files$/, "")}
+              to={getGitHubPrUrl(conversation.github_pr)}
               target="_blank"
               noreferrer="noreferrer"
               noopener="noopener"

--- a/client/src/pages/dashboard/fip_tracker/index.tsx
+++ b/client/src/pages/dashboard/fip_tracker/index.tsx
@@ -168,7 +168,7 @@ const FipTracker = () => {
       // the conversation's displayed title must include the search string, if it is given
       if (
         searchParam &&
-        !conversation.displayed_title.toLowerCase().includes(searchParam.toLowerCase())
+        !(conversation.displayed_title || "").toLowerCase().includes(searchParam.toLowerCase())
       ) {
         return false
       }

--- a/client/src/pages/dashboard/fip_tracker/useFipDisplayOptions.ts
+++ b/client/src/pages/dashboard/fip_tracker/useFipDisplayOptions.ts
@@ -24,10 +24,11 @@ export const useFipDisplayOptions = () => {
   const [sortBy, setSortBy] = useState<"desc" | "asc">(initialSavedDisplayOptions.sortBy)
 
   const resetDisplayOptions = () => {
-    setShowAuthors(true)
-    setShowCategory(true)
-    setShowCreationDate(true)
-    setShowType(true)
+    setShowAuthors(initialSavedDisplayOptions.showAuthors)
+    setShowCategory(initialSavedDisplayOptions.showCategory)
+    setShowCreationDate(initialSavedDisplayOptions.showCreationDate)
+    setShowType(initialSavedDisplayOptions.showType)
+    setSortBy(initialSavedDisplayOptions)
   }
 
   const saveDisplayOptions = () => {

--- a/client/src/pages/dashboard/fip_tracker/useFipDisplayOptions.ts
+++ b/client/src/pages/dashboard/fip_tracker/useFipDisplayOptions.ts
@@ -1,4 +1,5 @@
 import { useState } from "react"
+import { toast } from "react-hot-toast"
 import { useLocalStorage } from "usehooks-ts"
 
 export const useFipDisplayOptions = () => {
@@ -24,14 +25,16 @@ export const useFipDisplayOptions = () => {
   const [sortBy, setSortBy] = useState<"desc" | "asc">(initialSavedDisplayOptions.sortBy)
 
   const resetDisplayOptions = () => {
+    toast.success("Reset saved display options for FIP Tracker")
     setShowAuthors(initialSavedDisplayOptions.showAuthors)
     setShowCategory(initialSavedDisplayOptions.showCategory)
     setShowCreationDate(initialSavedDisplayOptions.showCreationDate)
     setShowType(initialSavedDisplayOptions.showType)
-    setSortBy(initialSavedDisplayOptions)
+    setSortBy(initialSavedDisplayOptions.sortBy)
   }
 
   const saveDisplayOptions = () => {
+    toast.success("Saved display options for FIP Tracker")
     setSavedDisplayOptions(
       JSON.stringify({ showAuthors, showCategory, showCreationDate, showType, sortBy }),
     )

--- a/client/src/pages/dashboard/front_matter.tsx
+++ b/client/src/pages/dashboard/front_matter.tsx
@@ -5,6 +5,7 @@ import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 
 import { ZidMetadata } from "../../util/types"
+import { getGitHubPrUrl } from "../../util/github_pr"
 
 type FrontmatterProps = { zid_metadata: ZidMetadata }
 
@@ -108,7 +109,7 @@ export const Frontmatter = ({ zid_metadata }: FrontmatterProps) => {
               <Text sx={{ fontWeight: "700" }}>PR</Text>
             </td>
             <td>
-              <Link target="_blank" rel="noopener noreferrer" href={fip_version.github_pr.url}>
+              <Link target="_blank" rel="noopener noreferrer" href={getGitHubPrUrl(fip_version.github_pr)}>
                 {fip_version.github_pr.title} (#{fip_version.github_pr.id})
               </Link>
             </td>
@@ -159,7 +160,7 @@ export const Frontmatter = ({ zid_metadata }: FrontmatterProps) => {
                 <Text sx={{ fontWeight: "700" }}>Files Updated</Text>
               </td>
               <td>
-                <Link target="_blank" rel="noopener noreferrer" href={fip_version.github_pr.url}>
+                <Link target="_blank" rel="noopener noreferrer" href={getGitHubPrUrl(fip_version.github_pr)}>
                   {fip_version.fip_files_updated}
                 </Link>
               </td>

--- a/client/src/pages/dashboard/index.tsx
+++ b/client/src/pages/dashboard/index.tsx
@@ -10,7 +10,7 @@ import { DashboardUserButton } from "./user_button"
 import { LandingPage } from "./landing_page"
 import { DashboardConversation } from "./conversation"
 import Sidebar from "./sidebar"
-const SentimentChecks = React.lazy(() => import("./sentiment_checks"))
+const DiscussionPolls = React.lazy(() => import("./discussion_polls"))
 const FipTracker = React.lazy(() => import("./fip_tracker/index.js"))
 
 type DashboardProps = {
@@ -45,11 +45,11 @@ const Dashboard = ({ user }: DashboardProps) => {
           <CompatRoutes>
             <CompatRoute path="/" element={<LandingPage />} />
             <CompatRoute
-              path="/sentiment_checks"
+              path="/discussion_polls"
               element={
                 <Suspense>
                   {" "}
-                  <SentimentChecks />
+                  <DiscussionPolls />
                 </Suspense>
               }
             />

--- a/client/src/pages/dashboard/sidebar.tsx
+++ b/client/src/pages/dashboard/sidebar.tsx
@@ -104,9 +104,9 @@ const Sidebar = ({ mobileMenuOpen }: { mobileMenuOpen: boolean }) => {
           </Link>
         </Flex>
         <ListingSelector
-          to="/dashboard/sentiment_checks"
+          to="/dashboard/discussion_polls"
           iconType={BiSolidBarChartAlt2}
-          label="Sentiment Checks"
+          label="Discussion Polls"
         />
         <ListingSelector to="/dashboard/fip_tracker" iconType={TbFocus} label="FIP Tracker" />
         <ConversationsList selectedView={selectedView} setSelectedView={setSelectedView} />

--- a/client/src/pages/dashboard/sidebar.tsx
+++ b/client/src/pages/dashboard/sidebar.tsx
@@ -8,8 +8,7 @@ import ConversationsList from "./conversations_list"
 import { BiSolidBarChartAlt2 } from "react-icons/bi"
 import { ListingSelector } from "./listing_selector"
 import { TbFocus } from "react-icons/tb"
-import { Box, Button, Flex, Link, Text } from "@radix-ui/themes"
-import { useNavigate } from "react-router-dom-v5-compat"
+import { Box, Flex, Link, Text } from "@radix-ui/themes"
 
 const LogoBlock = () => {
   return (
@@ -41,32 +40,6 @@ const LastSync = ({
           {syncInProgress ? <Spinner size={26} /> : `Sync now`}
         </Link>
       </Text>
-    </Flex>
-  )
-}
-
-const ViewAllButton = ({ selectedView }: { selectedView: "all" | "fips" | "polls" }) => {
-  const navigate = useNavigate()
-
-  if (selectedView === "all") return null
-
-  return (
-    <Flex justify="center" align="center" p="3">
-      <Button
-        size="3"
-        style={{ width: "100%", height: "37px", fontSize: "0.94em" }}
-        color="gray"
-        variant="soft"
-        onClick={() => {
-          if (selectedView === "fips") {
-            navigate("/dashboard/fip_tracker")
-          } else {
-            navigate("/dashboard/sentiment_checks")
-          }
-        }}
-      >
-        View all
-      </Button>
     </Flex>
   )
 }
@@ -136,13 +109,7 @@ const Sidebar = ({ mobileMenuOpen }: { mobileMenuOpen: boolean }) => {
           label="Sentiment Checks"
         />
         <ListingSelector to="/dashboard/fip_tracker" iconType={TbFocus} label="FIP Tracker" />
-        <Box pl="4" pb="2" pt="16px">
-          <Text size="1" color="gray">
-            Recently Active
-          </Text>
-        </Box>
         <ConversationsList selectedView={selectedView} setSelectedView={setSelectedView} />
-        <ViewAllButton selectedView={selectedView} />
         <LastSync lastSync={lastSync} syncInProgress={syncInProgress} syncPRs={syncPRs} />
       </div>
     </Box>

--- a/client/src/util/github_pr.ts
+++ b/client/src/util/github_pr.ts
@@ -1,0 +1,6 @@
+import { GitHubPr } from "./types"
+
+const FIP_REPO_OWNER = process.env.FIP_REPO_OWNER || "filecoin-project"
+const FIP_REPO_NAME = process.env.FIP_REPO_NAME || "FIPs"
+
+export const getGitHubPrUrl = (github_pr: GitHubPr) => `https://github.com/${FIP_REPO_OWNER}/${FIP_REPO_NAME}/pull/${github_pr.id}`

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -7848,9 +7848,6 @@ where conversation_sentiment_votes.zid = ($1);`,
         [conv.fip_version.github_pr_id],
       );
       conv.fip_version.github_pr = githubPrRows[0];
-      conv.fip_version.github_pr_url = `https://github.com/${process.env.FIP_REPO_OWNER}/${process.env.FIP_REPO_NAME}/pull/${conv.github_pr_id}/files`
-    } else {
-      conv.fip_version.github_pr_url = null
     }
   }
 
@@ -7915,12 +7912,6 @@ async function handle_GET_conversations(
     }
 
     conv.is_mod = uid && isAdministrator(uid)
-
-    if (conv.github_pr_id !== null) {
-      conv.github_pr_url = `https://github.com/${process.env.FIP_REPO_OWNER}/${process.env.FIP_REPO_NAME}/pull/${conv.github_pr_id}/files`
-    } else {
-      conv.github_pr_url = null
-    }
 
     // Make sure zid is not exposed
     delete conv.zid
@@ -7994,9 +7985,7 @@ async function handle_GET_conversations_summary(req: Request, res: Response) {
     if(fipVersionsById[conversation.fip_version_id]) {
       conversation.fip_version = fipVersionsById[conversation.fip_version_id]
       if (conversation.fip_version.github_pr_id !== null) {
-        const githubPr = githubPrsById[conversation.fip_version.github_pr_id]
-        githubPr.url = `https://github.com/${process.env.FIP_REPO_OWNER}/${process.env.FIP_REPO_NAME}/pull/${conversation.fip_version.github_pr_id}/files`
-        conversation.fip_version.github_pr = githubPr
+        conversation.fip_version.github_pr = githubPrsById[conversation.fip_version.github_pr_id]
       }
     } else {
       conversation.fip_version = null
@@ -8028,11 +8017,6 @@ async function handle_GET_fips(req: Request, res: Response) {
     const pr = github_prs_by_id[fip_row.github_pr_id]
     fip_row.github_pr = pr || null
     delete fip_row.github_pr_id
-
-
-    if (fip_row.github_pr !== null) {
-      fip_row.github_pr.url = `https://github.com/${process.env.FIP_REPO_OWNER}/${process.env.FIP_REPO_NAME}/pull/${fip_row.github_pr.id}/files`
-    }
   }
 
   return res.json(fip_rows)


### PR DESCRIPTION
Issue: https://github.com/canvasxyz/metropolis/issues/78

- [ ] ~~Unchecking “Category” on the Display menu doesn’t do anything, it should hide the Category label~~
- [x] Save as Default should cause a toast to pop up saying "View saved" (Feedback: And if I click on “Save as default”, I don’t see any kind of feedback that my selection has been saved as default.)
- [x] PR links are broken on [https://poll.fil.org/dashboard/c/7ns6n3hmta](https://poll.fil.org/dashboard/c/7ns6n3hmta)
- [ ] Polls are missing from `conversations_summary` route, and as a result none are visible on the homepage. Might need to make separate `conversations_summary` queries inside handle_GET_conversations_summary to get conversations with Github PRs, vs. those without. - they aren't missing, but the frontend filtering is inconsistent across views, see https://github.com/canvasxyz/metropolis/issues/80
- [x] Remove View all button ~~FIPs tab incorrectly links to Sentiment Checks ("On the “FIPs” tab, if I click on a specific FIP it takes me to a Sentiment Check page, but if I click on “View all”, it takes me to the FIP Tracker tab, which is a bit confusing.")~~
- [x] Remove “Recently Active” label from sidebar
- [x] Rename Sentiment Checks to Discussion Polls
- [x] Instead of toggling open Sentiment Checks from the listing page, clicking on a sentiment check card should link to its page (just like clicking on it in the sidebar)
- [ ] Sentiment checks should not show "Untitled" blank entries (many of these in prod right now) - we have some invalid data on prod that should be deleted
- [x] Fix bug where if there are any conversations where `.displayed_title` is null, search breaks

