### PR TITLE
Display only one FIP version per FIP number

### DIFF
--- a/client/src/pages/dashboard/fip_tracker/fip_entry.tsx
+++ b/client/src/pages/dashboard/fip_tracker/fip_entry.tsx
@@ -78,6 +78,7 @@ export const FipEntry = ({
   conversation: FipVersion & {
     displayed_title: string
     fip_authors: UserInfo[]
+    fipStatusKey: keyof typeof statusOptions
   }
   showAuthors: boolean
   showCategory: boolean
@@ -86,20 +87,10 @@ export const FipEntry = ({
 }) => {
   const [isOpen, setIsOpen] = useState(false)
 
-  let fipStatusKey = conversation.fip_status.toLowerCase().replace(" ", "-")
-  if (fipStatusKey === "wip") {
-    fipStatusKey = "draft"
-  } else if (!conversation.fip_status) {
-    fipStatusKey = "unknown"
-  }
-  if (conversation.github_pr?.merged_at || conversation.github_pr?.closed_at) {
-    fipStatusKey = "closed"
-  }
-
-  const fipStatusInfo = fipStatusKey ? statusOptions[fipStatusKey] : statusOptions.draft
-  const fipStatusLabel = statusOptions[fipStatusKey]
-    ? statusOptions[fipStatusKey].label
-    : fipStatusKey
+  const fipStatusInfo = conversation.fipStatusKey ? statusOptions[conversation.fipStatusKey] : statusOptions.draft
+    const fipStatusLabel = statusOptions[conversation.fipStatusKey]
+      ? statusOptions[conversation.fipStatusKey].label
+      : conversation.fipStatusKey
 
   const fipBadges = []
   if (showType && conversation.fip_type) {

--- a/client/src/pages/dashboard/fip_tracker/index.tsx
+++ b/client/src/pages/dashboard/fip_tracker/index.tsx
@@ -99,6 +99,7 @@ function processFipVersions(data: FipVersion[]) {
       // otherwise return the closed PRs
       return rows
     })
+    // flatten the groups so that we have a list of fip_versions entries
     .flat()
     // don't show fips that don't have a fip status
     .filter((conversation) => conversation.fip_status !== null)

--- a/client/src/pages/dashboard/fip_tracker/status_options.ts
+++ b/client/src/pages/dashboard/fip_tracker/status_options.ts
@@ -1,4 +1,5 @@
-export const statusOptions = {
+type Color = "gray" | "gold" | "bronze" | "brown" | "yellow" | "amber" | "orange" | "tomato" | "red" | "ruby" | "crimson" | "pink" | "plum" | "purple" | "violet" | "iris" | "indigo" | "blue" | "cyan" | "teal" | "jade" | "green" | "grass" | "lime" | "mint" | "sky"
+export const statusOptions: Record<string, {label: string, color: Color }> = {
   draft: {
     label: "Draft",
     color: "gray",
@@ -33,7 +34,7 @@ export const statusOptions = {
   },
   unknown: {
     label: "Unknown",
-    color: "slate",
+    color: "gray",
   },
   closed: {
     label: "Closed",


### PR DESCRIPTION
This PR modifies the `processFipVersions` function in the FIP tracker frontend to ensure that we display at most one FIP version per FIP number.

Algorithm:

1. Group FIP versions by fip_number, then iterate over each group
2. If the fip_number is null or zero, then display all FIPs that are open PRs
3. Else if there is a FIP version without a `github_pr` value, i.e. a "master" version, then display this
4. Else if there are any open PRs then display them
5. Else if there are any closed PRs then display them

The PR also cleans up some of the processing code to be more functional and adds a number of comments explaining each steps. The above algorithm is also written in the comments.

I've QA'd this code by opening the FIP Tracker in my local build (which is synced with the Filecoin FIPs repo) and checking that there is at most one entry per FIP version.