### PR TITLE
Infinite scrolling

### DIFF
--- a/client/src/components/IsVisibleObserver.tsx
+++ b/client/src/components/IsVisibleObserver.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useRef } from "react";
+
+export const IsVisibleObserver = ({ callback }: { callback: () => void }) => {
+  /*
+   * This is a special component that uses the IntersectionObserver to watch for when it
+   * comes into view and calls the `callback` prop.
+   * It can be used to implement an "infinite" scrolling list by putting it at the end of
+   * a scrollable list and then using the callback to request more data.
+   * See: https://blog.logrocket.com/infinite-scrolling-react/
+   */
+
+  const ref = useRef()
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      entries => {
+        if (entries[0].isIntersecting) {
+          callback()
+        }
+      },
+      { threshold: 1 }
+    );
+
+    if (ref.current) {
+      observer.observe(ref.current);
+    }
+
+    return () => {
+      if (ref.current) {
+        observer.unobserve(ref.current);
+      }
+    };
+  }, [ref]);
+
+  return <div ref={ref} />
+}

--- a/client/src/pages/dashboard/fip_tracker/index.tsx
+++ b/client/src/pages/dashboard/fip_tracker/index.tsx
@@ -168,7 +168,7 @@ const FipTracker = () => {
 
   const searchParam = searchParams.get("search") || ""
 
-  const [numEntriesToShow, setNumEntriesToShow] = useState(0)
+  const [scrollCursor, setScrollCursor] = useState(0)
   const scrollPageSize = 10
 
   const { data } = useSWR(
@@ -277,7 +277,7 @@ const FipTracker = () => {
       return true
     })
     .toSorted(sortFunction)
-    .slice(0, numEntriesToShow + scrollPageSize)
+    .slice(0, scrollCursor + scrollPageSize)
 
   return (
     <Flex
@@ -296,7 +296,7 @@ const FipTracker = () => {
             placeholder="Search..."
             value={(searchParams as any).get("search") || ""}
             onChange={(e) => {
-              setNumEntriesToShow(0)
+              setScrollCursor(0)
               setSearchParams({ search: e.target.value })
             }}
           >
@@ -326,7 +326,7 @@ const FipTracker = () => {
                     !unlabeledAuthorDeselected
                   }
                   setChecked={(value) => {
-                    setNumEntriesToShow(0)
+                    setScrollCursor(0)
                     setDeselectedFipAuthors(() =>
                       Object.fromEntries(
                         Object.keys(allFipAuthors || {}).map((key) => [key, !value]),
@@ -345,7 +345,7 @@ const FipTracker = () => {
                   }}
                   showOnly={true}
                   selectOnly={() => {
-                    setNumEntriesToShow(0)
+                    setScrollCursor(0)
                     setDeselectedFipAuthors(() =>
                       Object.fromEntries(
                         Object.keys(allFipAuthors || {}).map((key) => [key, true]),
@@ -365,12 +365,12 @@ const FipTracker = () => {
                       color={"blue"}
                       checked={deselectedFipAuthors[fipAuthor] !== true}
                       setChecked={(value) => {
-                        setNumEntriesToShow(0)
+                        setScrollCursor(0)
                         setDeselectedFipAuthors((prev) => ({ ...prev, [fipAuthor]: !value }))
                       }}
                       showOnly={true}
                       selectOnly={() => {
-                        setNumEntriesToShow(0)
+                        setScrollCursor(0)
                         setDeselectedFipAuthors(() =>
                           Object.fromEntries(
                             Object.keys(allFipAuthors || {}).map((key) => [key, key !== fipAuthor]),
@@ -394,7 +394,7 @@ const FipTracker = () => {
                   color={"blue"}
                   checked={Object.values(selectedFipStatuses).every((value) => value === true)}
                   setChecked={(value) => {
-                    setNumEntriesToShow(0)
+                    setScrollCursor(0)
                     setSelectedFipStatuses(() =>
                       Object.fromEntries(allFipStatuses.map((key) => [key, value])),
                     )
@@ -409,12 +409,12 @@ const FipTracker = () => {
                     color={statusOptions[fipStatus].color}
                     checked={selectedFipStatuses[fipStatus]}
                     setChecked={(value) => {
-                      setNumEntriesToShow(0)
+                      setScrollCursor(0)
                       setSelectedFipStatuses((prev) => ({ ...prev, [fipStatus]: value }))
                     }}
                     showOnly={true}
                     selectOnly={() => {
-                      setNumEntriesToShow(0)
+                      setScrollCursor(0)
                       setSelectedFipStatuses(() =>
                         Object.fromEntries(allFipStatuses.map((key) => [key, key === fipStatus])),
                       )
@@ -445,7 +445,7 @@ const FipTracker = () => {
                   color={"blue"}
                   checked={Object.values(deselectedFipTypes).every((value) => value !== true)}
                   setChecked={(value) => {
-                    setNumEntriesToShow(0)
+                    setScrollCursor(0)
                     setDeselectedFipTypes(() =>
                       Object.fromEntries(allFipTypes.map((key) => [key, !value])),
                     )
@@ -460,12 +460,12 @@ const FipTracker = () => {
                     color={"blue"}
                     checked={deselectedFipTypes[fipType] !== true}
                     setChecked={(value) => {
-                      setNumEntriesToShow(0)
+                      setScrollCursor(0)
                       setDeselectedFipTypes((prev) => ({ ...prev, [fipType]: !value }))
                     }}
                     showOnly={true}
                     selectOnly={() => {
-                      setNumEntriesToShow(0)
+                      setScrollCursor(0)
                       setDeselectedFipTypes(() =>
                         Object.fromEntries(allFipTypes.map((key) => [key, key !== fipType])),
                       )
@@ -549,7 +549,7 @@ const FipTracker = () => {
           />
         ))}
       </Flex>
-      <Box top="-20px"><IsVisibleObserver callback={() => setNumEntriesToShow((oldValue) => oldValue + scrollPageSize)}/></Box>
+      <Box top="-20px"><IsVisibleObserver callback={() => setScrollCursor((oldValue) => oldValue + scrollPageSize)}/></Box>
     </Flex>
   )
 }

--- a/client/src/pages/dashboard/fip_tracker/index.tsx
+++ b/client/src/pages/dashboard/fip_tracker/index.tsx
@@ -21,6 +21,7 @@ import { useFipDisplayOptions } from "./useFipDisplayOptions"
 import { DatePicker, DateRange } from "./date_picker"
 import { FipVersion } from "../../../util/types"
 import { getAuthorKey, splitAuthors, UserInfo } from "./splitAuthors"
+import { IsVisibleObserver } from "../../../components/IsVisibleObserver"
 
 function cleanFipType(originalFipType: string) {
   let fip_type = ""
@@ -167,6 +168,9 @@ const FipTracker = () => {
 
   const searchParam = searchParams.get("search") || ""
 
+  const [numEntriesToShow, setNumEntriesToShow] = useState(0)
+  const scrollPageSize = 10
+
   const { data } = useSWR(
     `fips`,
     async () => {
@@ -273,6 +277,7 @@ const FipTracker = () => {
       return true
     })
     .toSorted(sortFunction)
+    .slice(0, numEntriesToShow + scrollPageSize)
 
   return (
     <Flex
@@ -290,7 +295,10 @@ const FipTracker = () => {
           <TextField.Root
             placeholder="Search..."
             value={(searchParams as any).get("search") || ""}
-            onChange={(e) => setSearchParams({ search: e.target.value })}
+            onChange={(e) => {
+              setNumEntriesToShow(0)
+              setSearchParams({ search: e.target.value })
+            }}
           >
             <TextField.Slot>
               <TbSearch style={{ color: "#B4B6C2" }} />
@@ -318,6 +326,7 @@ const FipTracker = () => {
                     !unlabeledAuthorDeselected
                   }
                   setChecked={(value) => {
+                    setNumEntriesToShow(0)
                     setDeselectedFipAuthors(() =>
                       Object.fromEntries(
                         Object.keys(allFipAuthors || {}).map((key) => [key, !value]),
@@ -336,6 +345,7 @@ const FipTracker = () => {
                   }}
                   showOnly={true}
                   selectOnly={() => {
+                    setNumEntriesToShow(0)
                     setDeselectedFipAuthors(() =>
                       Object.fromEntries(
                         Object.keys(allFipAuthors || {}).map((key) => [key, true]),
@@ -355,10 +365,12 @@ const FipTracker = () => {
                       color={"blue"}
                       checked={deselectedFipAuthors[fipAuthor] !== true}
                       setChecked={(value) => {
+                        setNumEntriesToShow(0)
                         setDeselectedFipAuthors((prev) => ({ ...prev, [fipAuthor]: !value }))
                       }}
                       showOnly={true}
                       selectOnly={() => {
+                        setNumEntriesToShow(0)
                         setDeselectedFipAuthors(() =>
                           Object.fromEntries(
                             Object.keys(allFipAuthors || {}).map((key) => [key, key !== fipAuthor]),
@@ -382,6 +394,7 @@ const FipTracker = () => {
                   color={"blue"}
                   checked={Object.values(selectedFipStatuses).every((value) => value === true)}
                   setChecked={(value) => {
+                    setNumEntriesToShow(0)
                     setSelectedFipStatuses(() =>
                       Object.fromEntries(allFipStatuses.map((key) => [key, value])),
                     )
@@ -396,10 +409,12 @@ const FipTracker = () => {
                     color={statusOptions[fipStatus].color}
                     checked={selectedFipStatuses[fipStatus]}
                     setChecked={(value) => {
+                      setNumEntriesToShow(0)
                       setSelectedFipStatuses((prev) => ({ ...prev, [fipStatus]: value }))
                     }}
                     showOnly={true}
                     selectOnly={() => {
+                      setNumEntriesToShow(0)
                       setSelectedFipStatuses(() =>
                         Object.fromEntries(allFipStatuses.map((key) => [key, key === fipStatus])),
                       )
@@ -430,6 +445,7 @@ const FipTracker = () => {
                   color={"blue"}
                   checked={Object.values(deselectedFipTypes).every((value) => value !== true)}
                   setChecked={(value) => {
+                    setNumEntriesToShow(0)
                     setDeselectedFipTypes(() =>
                       Object.fromEntries(allFipTypes.map((key) => [key, !value])),
                     )
@@ -444,10 +460,12 @@ const FipTracker = () => {
                     color={"blue"}
                     checked={deselectedFipTypes[fipType] !== true}
                     setChecked={(value) => {
+                      setNumEntriesToShow(0)
                       setDeselectedFipTypes((prev) => ({ ...prev, [fipType]: !value }))
                     }}
                     showOnly={true}
                     selectOnly={() => {
+                      setNumEntriesToShow(0)
                       setDeselectedFipTypes(() =>
                         Object.fromEntries(allFipTypes.map((key) => [key, key !== fipType])),
                       )
@@ -531,6 +549,7 @@ const FipTracker = () => {
           />
         ))}
       </Flex>
+      <Box top="-20px"><IsVisibleObserver callback={() => setNumEntriesToShow((oldValue) => oldValue + scrollPageSize)}/></Box>
     </Flex>
   )
 }

--- a/client/src/pages/dashboard/polls/index.tsx
+++ b/client/src/pages/dashboard/polls/index.tsx
@@ -58,7 +58,7 @@ export default ({ only }: { only: string }) => {
   // We want to display the polls as an "infinite scrolling list"
   // The `scrollCursor` is the number of entries we want to display at a time
   // When the user scrolls to the bottom of the list, this cursor is incremented to add more items
-  const [numEntriesToShow, setNumEntriesToShow] = useState(0)
+  const [scrollCursor, setScrollCursor] = useState(0)
   const scrollPageSize = 10
 
   const { data } = useSWR(
@@ -122,7 +122,7 @@ export default ({ only }: { only: string }) => {
       return true
     })
     .toSorted(sortFunction)
-    .slice(0, numEntriesToShow + scrollPageSize)
+    .slice(0, scrollCursor + scrollPageSize)
 
 
   return (
@@ -158,7 +158,7 @@ export default ({ only }: { only: string }) => {
               placeholder="Search..."
               value={(searchParams as any).get("search") || ""}
               onChange={(e) => {
-                setNumEntriesToShow(0)
+                setScrollCursor(0)
                 setSearchParams({ search: e.target.value })
               }}
             >
@@ -188,7 +188,7 @@ export default ({ only }: { only: string }) => {
                   (value) => value === true,
                 )}
                 setChecked={(value) => {
-                  setNumEntriesToShow(0)
+                  setScrollCursor(0)
                   setSelectedConversationStatuses(() =>
                     Object.fromEntries(allStatuses.map((key) => [key, value])),
                   )
@@ -203,7 +203,7 @@ export default ({ only }: { only: string }) => {
                   color={conversationStatusOptions[status].color}
                   checked={selectedConversationStatuses[status]}
                   setChecked={(value) => {
-                    setNumEntriesToShow(0)
+                    setScrollCursor(0)
                     setSelectedConversationStatuses((prev) => ({ ...prev, [status]: value }))
                   }}
                 >
@@ -227,7 +227,7 @@ export default ({ only }: { only: string }) => {
                   value={sortBy}
                   onValueChange={(v) => {
                     setSortBy(v as "asc" | "desc")
-                    setNumEntriesToShow(0)
+                    setScrollCursor(0)
                   }}
                 >
                   <Select.Trigger />
@@ -267,7 +267,7 @@ export default ({ only }: { only: string }) => {
             <Text color="gray">None matching filters</Text>
           )}
         </Flex>
-        <Box top="-20px"><IsVisibleObserver callback={() => setNumEntriesToShow((oldValue) => oldValue + scrollPageSize)}/></Box>
+        <Box top="-20px"><IsVisibleObserver callback={() => setScrollCursor((oldValue) => oldValue + scrollPageSize)}/></Box>
       </Flex>
       <CreateConversationModal
         isOpen={createConversationModalIsOpen}

--- a/client/src/pages/dashboard/polls/index.tsx
+++ b/client/src/pages/dashboard/polls/index.tsx
@@ -22,6 +22,7 @@ import { useAppSelector } from "../../../hooks"
 import { MIN_SEED_RESPONSES } from "../../../util/misc"
 import { CreateConversationModal } from "../../CreateConversationModal"
 import { useDiscussionPollDisplayOptions } from "./useDiscussionPollDisplayOptions"
+import { IsVisibleObserver } from "../../../components/IsVisibleObserver"
 
 const conversationStatusOptions = {
   open: { label: "Open", color: "blue" },
@@ -51,6 +52,12 @@ export default ({ only }: { only: string }) => {
     useDiscussionPollDisplayOptions()
 
   const [searchParams, setSearchParams] = useSearchParams()
+
+  // We want to display the polls as an "infinite scrolling list"
+  // The `scrollCursor` is the number of entries we want to display at a time
+  // When the user scrolls to the bottom of the list, this cursor is incremented to add more items
+  const [numEntriesToShow, setNumEntriesToShow] = useState(0)
+  const scrollPageSize = 10
 
   const searchParam = searchParams.get("search") || ""
 
@@ -115,6 +122,8 @@ export default ({ only }: { only: string }) => {
       return true
     })
     .toSorted(sortFunction)
+    .slice(0, numEntriesToShow + scrollPageSize)
+
 
   return (
     <Box>
@@ -138,6 +147,7 @@ export default ({ only }: { only: string }) => {
           flexDirection: "column",
           gap: [3],
         }}
+        id="scrollableDiv"
       >
         <Text sx={{ fontWeight: 600, fontSize: [2] }}>
           {only === "polls" ? <>Discussion Polling</> : <>Sentiment Checks</>}
@@ -147,7 +157,10 @@ export default ({ only }: { only: string }) => {
             <TextField.Root
               placeholder="Search..."
               value={(searchParams as any).get("search") || ""}
-              onChange={(e) => setSearchParams({ search: e.target.value })}
+              onChange={(e) => {
+                setNumEntriesToShow(0)
+                setSearchParams({ search: e.target.value })
+              }}
             >
               <TextField.Slot>
                 <TbSearch style={{ color: "#B4B6C2" }} />
@@ -175,6 +188,7 @@ export default ({ only }: { only: string }) => {
                   (value) => value === true,
                 )}
                 setChecked={(value) => {
+                  setNumEntriesToShow(0)
                   setSelectedConversationStatuses(() =>
                     Object.fromEntries(allStatuses.map((key) => [key, value])),
                   )
@@ -189,6 +203,7 @@ export default ({ only }: { only: string }) => {
                   color={conversationStatusOptions[status].color}
                   checked={selectedConversationStatuses[status]}
                   setChecked={(value) => {
+                    setNumEntriesToShow(0)
                     setSelectedConversationStatuses((prev) => ({ ...prev, [status]: value }))
                   }}
                 >
@@ -210,7 +225,10 @@ export default ({ only }: { only: string }) => {
                 <Select.Root
                   defaultValue={sortBy || "desc"}
                   value={sortBy}
-                  onValueChange={(v) => setSortBy(v as "asc" | "desc")}
+                  onValueChange={(v) => {
+                    setSortBy(v as "asc" | "desc")
+                    setNumEntriesToShow(0)
+                  }}
                 >
                   <Select.Trigger />
                   <Select.Content>
@@ -249,6 +267,7 @@ export default ({ only }: { only: string }) => {
             <Text color="gray">None matching filters</Text>
           )}
         </Flex>
+        <Box top="-20px"><IsVisibleObserver callback={() => setNumEntriesToShow((oldValue) => oldValue + scrollPageSize)}/></Box>
       </Flex>
       <CreateConversationModal
         isOpen={createConversationModalIsOpen}

--- a/client/src/pages/dashboard/polls/index.tsx
+++ b/client/src/pages/dashboard/polls/index.tsx
@@ -53,13 +53,13 @@ export default ({ only }: { only: string }) => {
 
   const [searchParams, setSearchParams] = useSearchParams()
 
+  const searchParam = searchParams.get("search") || ""
+
   // We want to display the polls as an "infinite scrolling list"
   // The `scrollCursor` is the number of entries we want to display at a time
   // When the user scrolls to the bottom of the list, this cursor is incremented to add more items
   const [numEntriesToShow, setNumEntriesToShow] = useState(0)
   const scrollPageSize = 10
-
-  const searchParam = searchParams.get("search") || ""
 
   const { data } = useSWR(
     `conversations_summary_discussion_polls_${only}`,


### PR DESCRIPTION
This PR adds a simple mechanism for infinite scrolling to the Polls and FIP Tracker pages.

Since all of the conversation data is loaded onto the client, the point of this feature is not to reduce load on the database but purely to make the UI more responsive - if we are trying to display all of the conversations and apply a filter, this can involve having to reflow the layout for hundreds of components, which can take hundreds of milliseconds, leading to noticeable lag. It seems like the problem here really is just reflowing the layout, I had hoped that it was something to do with React memoising props since that would have been fixable by refactoring the components themselves...

Changes:

- A (number, integer) state `scrollCursor` which shows the current "cursor"
- An invisible `IsVisibleObserver` component which is added to the end of the list of items. When it comes into view, increment `scrollCursor` by some fixed amount (e.g. 10)
- When we display the conversations, only show the first `scrollCursor + pageSize`. Set `pageSize` to whatever the number of items to initially show is.

Note that this mechanism assumes that the filters can only be set from the top of the page - which is currently how the filter dropdowns work. 