### PR TITLE
Allow users to filter polls by "Needs Seed Responses"

### DIFF
--- a/client/src/pages/dashboard/polls/conversation_entry.tsx
+++ b/client/src/pages/dashboard/polls/conversation_entry.tsx
@@ -91,7 +91,7 @@ export const ConversationEntry = ({
               ))}
             {
               conversation.conversation_status === "needs_responses" &&
-              <Text ml="3" color="red" style={{ flex: 1, lineHeight: 1.3, fontSize: "95%", fontWeight: 500 }}>
+              <Text ml="3" color="red" >
                 (Needs seed responses)
               </Text>
             }

--- a/client/src/pages/dashboard/polls/conversation_entry.tsx
+++ b/client/src/pages/dashboard/polls/conversation_entry.tsx
@@ -7,11 +7,14 @@ import { ConversationSummary } from "../../../reducers/conversations_summary"
 import { getIconForConversation, getColorForConversation } from "../conversation_list_item"
 import { useNavigate } from "react-router-dom-v5-compat"
 
+export type ConversationStatus = "open" | "needs_responses" | "closed"
+
 export const ConversationEntry = ({
   conversation,
   showCreationDate,
 }: {
   conversation: ConversationSummary & {
+    conversation_status: ConversationStatus
     displayed_title: string
   }
   showCreationDate: boolean
@@ -86,6 +89,12 @@ export const ConversationEntry = ({
               ) : (
                 <Text sx={{ color: "#84817D" }}>Untitled</Text>
               ))}
+            {
+              conversation.conversation_status === "needs_responses" &&
+              <Text ml="3" color="red" style={{ flex: 1, lineHeight: 1.3, fontSize: "95%", fontWeight: 500 }}>
+                (Needs seed responses)
+              </Text>
+            }
           </Text>
           <Badge
             size="2"

--- a/client/src/pages/dashboard/polls/index.tsx
+++ b/client/src/pages/dashboard/polls/index.tsx
@@ -25,6 +25,7 @@ import { useDiscussionPollDisplayOptions } from "./useDiscussionPollDisplayOptio
 
 const conversationStatusOptions = {
   open: { label: "Open", color: "blue" },
+  needs_responses: { label: "Needs Responses", color: "red"},
   closed: { label: "Closed", color: "gray" },
 }
 
@@ -37,7 +38,7 @@ export const TopRightFloating = ({ children }: { children: React.ReactNode }) =>
 }
 
 export default ({ only }: { only: string }) => {
-  const allStatuses = ["open", "closed"]
+  const allStatuses = ["open", "needs_responses", "closed"]
   const [selectedConversationStatuses, setSelectedConversationStatuses] = useState<
     Record<string, boolean>
   >({
@@ -91,11 +92,6 @@ export default ({ only }: { only: string }) => {
 
   const displayedConversations = (conversations || [])
     .filter((conversation) => {
-      // Filter out conversations with insufficient seed responses
-      if (!conversation.fip_version && conversation.comment_count < MIN_SEED_RESPONSES) {
-        return false
-      }
-
       // the conversation's displayed title must include the search string, if it is given
       if (
         searchParam &&
@@ -104,11 +100,11 @@ export default ({ only }: { only: string }) => {
         return false
       }
 
-      if (conversation.is_archived && !selectedConversationStatuses.closed) {
-        return false
-      }
-
-      if (!conversation.is_archived && !selectedConversationStatuses.open) {
+      const conversationStatus =
+        conversation.is_archived ? "closed" :
+        !conversation.fip_version && conversation.comment_count < MIN_SEED_RESPONSES ? "needs_responses" :
+        "open"
+      if (!selectedConversationStatuses[conversationStatus]) {
         return false
       }
 

--- a/client/src/pages/dashboard/polls/index.tsx
+++ b/client/src/pages/dashboard/polls/index.tsx
@@ -17,7 +17,7 @@ import { ClickableChecklistItem } from "../../../components/ClickableChecklistIt
 import { useFipDisplayOptions } from "../fip_tracker/useFipDisplayOptions"
 import { DatePicker, DateRange } from "../fip_tracker/date_picker"
 import { ConversationSummary } from "../../../reducers/conversations_summary"
-import { ConversationEntry } from "./conversation_entry"
+import { ConversationEntry, ConversationStatus } from "./conversation_entry"
 import { useAppSelector } from "../../../hooks"
 import { MIN_SEED_RESPONSES } from "../../../util/misc"
 import { CreateConversationModal } from "../../CreateConversationModal"
@@ -29,7 +29,7 @@ const conversationStatusOptions = {
   closed: { label: "Closed", color: "gray" },
 }
 
-const getSelectedConversationStatusesLabel = (selectedConversationStatuses: Record<keyof typeof conversationStatusOptions, boolean>) => {
+const getSelectedConversationStatusesLabel = (selectedConversationStatuses: Record<ConversationStatus, boolean>) => {
   const entries = Object.entries(selectedConversationStatuses)
   const selectedEntries = entries.filter(([,v]) => v)
 
@@ -86,7 +86,7 @@ export default ({ only }: { only: string }) => {
       const conversationsWithExtraFields = conversations.map((conversation) => {
         const displayed_title = conversation.topic
 
-        const conversation_status = conversation.is_archived ? "closed" :
+        const conversation_status: ConversationStatus = conversation.is_archived ? "closed" :
           !conversation.fip_version && conversation.comment_count < MIN_SEED_RESPONSES ? "needs_responses" :
           "open"
 

--- a/client/src/pages/dashboard/polls/index.tsx
+++ b/client/src/pages/dashboard/polls/index.tsx
@@ -25,7 +25,7 @@ import { useDiscussionPollDisplayOptions } from "./useDiscussionPollDisplayOptio
 
 const conversationStatusOptions = {
   open: { label: "Open", color: "blue" },
-  needs_responses: { label: "Needs Responses", color: "red"},
+  needs_responses: { label: "Needs Seed Responses", color: "red"},
   closed: { label: "Closed", color: "gray" },
 }
 


### PR DESCRIPTION
This PR adds another "status" option to the Filter dropdown in the Polls view, which allows users to view polls that need seed responses.

![Screenshot 2025-02-05 at 9 52 34 AM](https://github.com/user-attachments/assets/c0024c13-98fa-43ab-8f94-0fdae4ec2c46)
![Screenshot 2025-02-05 at 9 52 37 AM](https://github.com/user-attachments/assets/7383ff55-64d6-4b84-a07b-08406d04ead0)
![Screenshot 2025-02-05 at 9 52 43 AM](https://github.com/user-attachments/assets/055a450c-73bf-4bd5-9866-957f4edcc527)

It also adds a "Needs Seed Responses" label to polls:

![Screenshot 2025-02-05 at 10 02 47 AM](https://github.com/user-attachments/assets/a325f1e3-0274-4bf0-9d71-138702dea104)
